### PR TITLE
Add Prisma schema and seed

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,80 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum Provider {
+  WHATSAPP
+  SMS
+  EMAIL
+}
+
+enum Direction {
+  IN
+  OUT
+}
+
+enum Stage {
+  NEW
+  IN_PROGRESS
+  WAITING
+  DONE
+}
+
+enum Plan {
+  FREE
+  PRO
+}
+
+model User {
+  id             String          @id @default(uuid())
+  email          String          @unique
+  name           String?
+  contacts       Contact[]
+  deals          Deal[]
+  stripeCustomer StripeCustomer?
+}
+
+model Contact {
+  id       String   @id @default(uuid())
+  userId   String
+  user     User     @relation(fields: [userId], references: [id])
+  name     String
+  phone    String?
+  email    String?
+  messages Message[]
+  deals    Deal[]
+}
+
+model Message {
+  id        String     @id @default(uuid())
+  contactId String
+  contact   Contact    @relation(fields: [contactId], references: [id])
+  provider  Provider
+  body      String
+  direction Direction
+  sentAt    DateTime
+}
+
+model Deal {
+  id         String   @id @default(uuid())
+  userId     String
+  contactId  String
+  user       User     @relation(fields: [userId], references: [id])
+  contact    Contact  @relation(fields: [contactId], references: [id])
+  stage      Stage
+  reminderAt DateTime?
+}
+
+model StripeCustomer {
+  id               String   @id @default(uuid())
+  userId           String   @unique
+  user             User     @relation(fields: [userId], references: [id])
+  stripeId         String
+  plan             Plan
+  currentPeriodEnd DateTime
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,59 @@
+import { PrismaClient, Provider, Direction } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  const user = await prisma.user.create({
+    data: {
+      email: 'demo@example.com',
+      name: 'Demo User',
+    },
+  })
+
+  const contact1 = await prisma.contact.create({
+    data: {
+      userId: user.id,
+      name: 'Alice',
+      phone: '123-456-7890',
+      email: 'alice@example.com',
+    },
+  })
+
+  await prisma.message.create({
+    data: {
+      contactId: contact1.id,
+      provider: Provider.EMAIL,
+      body: 'Hello Alice!',
+      direction: Direction.OUT,
+      sentAt: new Date(),
+    },
+  })
+
+  const contact2 = await prisma.contact.create({
+    data: {
+      userId: user.id,
+      name: 'Bob',
+      phone: '987-654-3210',
+      email: 'bob@example.com',
+    },
+  })
+
+  await prisma.message.create({
+    data: {
+      contactId: contact2.id,
+      provider: Provider.SMS,
+      body: 'Hi Bob!',
+      direction: Direction.OUT,
+      sentAt: new Date(),
+    },
+  })
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })


### PR DESCRIPTION
## Summary
- define Prisma models for users, contacts, messages, deals and Stripe customers
- add seed script to create sample data

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68489f2e3648832aabdcfdb195780108