### PR TITLE
Add message webhooks

### DIFF
--- a/omnibox/apps/web/app/api/webhook/email/route.ts
+++ b/omnibox/apps/web/app/api/webhook/email/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { Provider } from "@prisma/client";
+import { upsertContactAndMessage, type EmailWebhook } from "../../../../lib/webhooks";
+
+export async function POST(req: Request) {
+  const form = await req.formData();
+  const payload: EmailWebhook = {
+    from: (form.get("from") as string) || "",
+    subject: (form.get("subject") as string) || "",
+    text: (form.get("text") as string) || "",
+  };
+  if (!payload.from) {
+    return new NextResponse("Bad Request", { status: 400 });
+  }
+  await upsertContactAndMessage(Provider.EMAIL, payload.from, payload.text, payload.from);
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/app/api/webhook/sms/route.ts
+++ b/omnibox/apps/web/app/api/webhook/sms/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { Provider } from "@prisma/client";
+import { upsertContactAndMessage, type SmsWebhook } from "../../../../lib/webhooks";
+
+export async function POST(req: Request) {
+  const text = await req.text();
+  const params = new URLSearchParams(text);
+  const payload: SmsWebhook = {
+    From: params.get("From") || "",
+    Body: params.get("Body") || "",
+  };
+  if (!payload.From) {
+    return new NextResponse("Bad Request", { status: 400 });
+  }
+  await upsertContactAndMessage(Provider.SMS, payload.From, payload.Body);
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/app/api/webhook/whatsapp/route.ts
+++ b/omnibox/apps/web/app/api/webhook/whatsapp/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { Provider } from "@prisma/client";
+import { upsertContactAndMessage, type WhatsAppWebhook } from "../../../../lib/webhooks";
+
+export async function POST(req: Request) {
+  const payload = (await req.json()) as WhatsAppWebhook;
+  const message = payload.entry?.[0]?.changes?.[0]?.value?.messages?.[0];
+  if (!message) {
+    return new NextResponse("Bad Request", { status: 400 });
+  }
+  const sentAt = new Date(Number(message.timestamp) * 1000);
+  await upsertContactAndMessage(
+    Provider.WHATSAPP,
+    message.from,
+    message.text?.body || "",
+    undefined,
+    sentAt
+  );
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/lib/webhooks.ts
+++ b/omnibox/apps/web/lib/webhooks.ts
@@ -1,0 +1,75 @@
+import { Provider, Direction } from "@prisma/client";
+import prisma from "./prisma";
+
+export async function upsertContactAndMessage(
+  provider: Provider,
+  from: string,
+  body: string,
+  email?: string,
+  sentAt: Date = new Date(),
+) {
+  const user = await prisma.user.findFirst();
+  if (!user) throw new Error("No user found");
+
+  let contact = await prisma.contact.findFirst({
+    where:
+      provider === Provider.EMAIL
+        ? { email: from }
+        : { phone: from },
+  });
+
+  if (!contact) {
+    contact = await prisma.contact.create({
+      data: {
+        userId: user.id,
+        name: from,
+        phone: provider === Provider.EMAIL ? undefined : from,
+        email: provider === Provider.EMAIL ? from : email,
+      },
+    });
+  } else {
+    const data: { phone?: string; email?: string } = {};
+    if (!contact.phone && provider !== Provider.EMAIL) data.phone = from;
+    if (!contact.email && email) data.email = email;
+    if (Object.keys(data).length) {
+      contact = await prisma.contact.update({ where: { id: contact.id }, data });
+    }
+  }
+
+  const message = await prisma.message.create({
+    data: {
+      contactId: contact.id,
+      provider,
+      body,
+      direction: Direction.IN,
+      sentAt,
+    },
+  });
+
+  return { contact, message };
+}
+
+export interface WhatsAppWebhook {
+  entry: Array<{
+    changes: Array<{
+      value: {
+        messages: Array<{
+          from: string;
+          text: { body: string };
+          timestamp: string;
+        }>;
+      };
+    }>;
+  }>;
+}
+
+export interface SmsWebhook {
+  From: string;
+  Body: string;
+}
+
+export interface EmailWebhook {
+  from: string;
+  subject: string;
+  text: string;
+}


### PR DESCRIPTION
## Summary
- add `upsertContactAndMessage` helper with webhook types
- implement `/api/webhook/whatsapp`
- implement `/api/webhook/sms`
- implement `/api/webhook/email`

## Testing
- `pnpm check-types` *(fails: ENETUNREACH)*
- `pnpm lint` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68496e0ca088832aab5c487be0fa5b97