### PR TITLE
Add messages API route

### DIFF
--- a/omnibox/apps/web/app/api/messages/route.ts
+++ b/omnibox/apps/web/app/api/messages/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import prisma from "../../../lib/prisma";
+import { serverSession } from "../../../lib/auth";
+
+const querySchema = z.object({
+  contactId: z.string().uuid(),
+});
+
+export async function GET(req: NextRequest) {
+  const session = await serverSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = (session.user as { id?: string })?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const contactId = url.searchParams.get("contactId");
+
+  const result = querySchema.safeParse({ contactId });
+  if (!result.success) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+
+  const contact = await prisma.contact.findFirst({
+    where: { id: result.data.contactId, userId },
+    select: { id: true },
+  });
+
+  if (!contact) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+
+  const messages = await prisma.message.findMany({
+    where: { contactId: contact.id },
+    orderBy: { sentAt: "desc" },
+    take: 50,
+    select: {
+      id: true,
+      provider: true,
+      body: true,
+      direction: true,
+      sentAt: true,
+    },
+  });
+
+  return NextResponse.json({ messages });
+}

--- a/omnibox/apps/web/package.json
+++ b/omnibox/apps/web/package.json
@@ -19,7 +19,8 @@
     "next-auth": "^4.24.11",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "resend": "^4.5.2"
+    "resend": "^4.5.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/omnibox/pnpm-lock.yaml
+++ b/omnibox/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       resend:
         specifier: ^4.5.2
         version: 4.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.61
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -2537,6 +2540,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.61:
+    resolution: {integrity: sha512-fzfJgUw78LTNnHujj9re1Ov/JJQkRZZGDMcYqSx7Hp4rPOkKywaFHq0S6GoHeXs0wGNE/sIOutkXgnwzrVOGCQ==}
 
 snapshots:
 
@@ -5193,3 +5199,5 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.61: {}


### PR DESCRIPTION
## Summary
- add `/api/messages` route to fetch messages for a contact
- enable zod and update lockfile

## Testing
- `pnpm --filter web check-types`
- `pnpm --filter web lint` *(fails: `next lint` reports existing warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6849a5e88dac832aa67829289804bb13