### PR TITLE
Add Tailwind CSS setup

### DIFF
--- a/omnibox/apps/web/app/dashboard/page.tsx
+++ b/omnibox/apps/web/app/dashboard/page.tsx
@@ -56,32 +56,41 @@ export default function Dashboard() {
     : "?"
 
   const Avatar = ({ label }: { label: string }) => (
-    <div className="w-8 h-8 flex items-center justify-center rounded-full bg-gray-300 text-xs font-medium text-gray-700">
+    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-xs font-medium text-gray-700">
       {label}
     </div>
   )
 
   return (
-    <div className="p-6 flex flex-col sm:flex-row gap-6 h-[calc(100vh-3rem)]">
+    <div className="flex flex-col gap-6 p-6 sm:flex-row h-[calc(100vh-3rem)]">
       {/* CONTACT LIST */}
-      <aside className="w-64">
-        <h2 className="font-bold mb-2">Contacts</h2>
-        {/* Show error if contacts failed to load */}
+      <aside className="flex-shrink-0 sm:w-64 border-gray-200 sm:border-r overflow-y-auto">
+        <h2 className="px-2 pb-2 text-lg font-semibold">Contacts</h2>
         {contactsError && (
-          <div className="text-red-500 mb-2">
+          <div className="mb-2 px-2 text-red-500">
             Error loading contacts: {contactsError.message || String(contactsError)}
           </div>
         )}
-        <ul>
+        <ul className="space-y-1 px-2 pb-4">
           {contacts?.contacts?.map((c: any) => (
             <li key={c.id}>
               <button
-                className={`block w-full text-left px-2 py-1 rounded ${
-                  c.id === contactId ? 'bg-gray-200' : ''
+                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left hover:bg-gray-100 ${
+                  c.id === contactId ? 'bg-gray-200 font-medium' : ''
                 }`}
                 onClick={() => setContactId(c.id)}
               >
-                {c.name || c.email || c.phone}
+                <Avatar label={
+                  c.name
+                    ? c.name
+                        .split(' ')
+                        .map((p: string) => p[0])
+                        .join('')
+                        .slice(0, 2)
+                        .toUpperCase()
+                    : '?'
+                } />
+                <span className="truncate">{c.name || c.email || c.phone}</span>
               </button>
             </li>
           ))}
@@ -89,49 +98,44 @@ export default function Dashboard() {
       </aside>
 
       {/* MESSAGE THREAD */}
-      <main className="flex-1 flex flex-col">
-        {!contactId && <p>Select a contact →</p>}
+      <main className="flex h-full flex-1 flex-col">
+        {!contactId && (
+          <div className="flex flex-1 items-center justify-center text-gray-500">
+            Select a contact
+          </div>
+        )}
         {contactId && (
           <>
-            <h2 className="font-bold mb-2">Messages</h2>
-            {/* Show error if messages failed to load */}
+            <div className="border-b border-gray-200 px-4 py-2 font-semibold">
+              {selectedContact?.name || selectedContact?.email || selectedContact?.phone}
+            </div>
             {messagesError && (
-              <div className="text-red-500 mb-2">
+              <div className="mb-2 px-4 text-red-500">
                 Error loading messages: {messagesError.message || String(messagesError)}
               </div>
             )}
-            <ul className="flex-1 overflow-y-auto space-y-3 pr-2">
+            <ul className="flex-1 space-y-3 overflow-y-auto p-4">
               {messages?.messages?.map((m: any) => (
-                <li
-                  key={m.id}
-                  className={`flex items-end gap-2 ${
-                    m.direction === 'OUT' ? 'justify-end' : 'justify-start'
-                  }`}
-                >
-                  {m.direction !== 'OUT' && <Avatar label={contactInitials} />}
-                  <div
-                    className={`rounded-xl px-3 py-2 max-w-[70%] text-sm break-words ${
-                      m.direction === 'OUT'
-                        ? 'bg-blue-600 text-white'
-                        : 'bg-gray-100 text-gray-900'
-                    }`}
-                  >
-                    <p>{m.body}</p>
-                    <span className="mt-1 block text-[10px] text-gray-500">
-                      {new Date(m.sentAt).toLocaleString()}
-                    </span>
+                <li key={m.id} className={`flex ${m.direction === 'OUT' ? 'justify-end' : 'justify-start'}`}>
+                  <div className={`flex items-end gap-2 ${m.direction === 'OUT' ? 'flex-row-reverse' : ''}`}>
+                    <Avatar label={m.direction === 'OUT' ? 'You' : contactInitials} />
+                    <div
+                      className={`max-w-[70%] break-words rounded-lg px-3 py-2 text-sm ${
+                        m.direction === 'OUT' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'
+                      }`}
+                    >
+                      <p>{m.body}</p>
+                      <span className="mt-1 block text-[10px] text-gray-500">
+                        {new Date(m.sentAt).toLocaleString()}
+                      </span>
+                    </div>
                   </div>
-                  {m.direction === 'OUT' && <Avatar label="You" />}
                 </li>
               ))}
             </ul>
-            {/* Outbound Message Input + Send Button */}
-            <form
-              onSubmit={sendMessage}
-              className="sticky bottom-0 left-0 right-0 mt-4 flex gap-2 bg-white p-2 sm:static"
-            >
+            <form onSubmit={sendMessage} className="flex gap-2 border-t border-gray-200 p-4">
               <input
-                className="border rounded px-2 py-1 flex-1"
+                className="flex-1 rounded border px-3 py-2"
                 placeholder="Type a message…"
                 value={messageBody}
                 onChange={(e) => setMessageBody(e.target.value)}
@@ -140,7 +144,7 @@ export default function Dashboard() {
               />
               <button
                 type="submit"
-                className="bg-blue-600 text-white px-3 py-1 rounded"
+                className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
                 disabled={!contactId || !messageBody.trim()}
               >
                 Send

--- a/omnibox/apps/web/app/globals.css
+++ b/omnibox/apps/web/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/omnibox/apps/web/package.json
+++ b/omnibox/apps/web/package.json
@@ -30,6 +30,10 @@
     "@types/react": "19.1.0",
     "@types/react-dom": "19.1.1",
     "eslint": "^9.28.0",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "tailwindcss": "^4.1.10",
+    "postcss": "^8.5.5",
+    "autoprefixer": "^10.4.21",
+    "@tailwindcss/postcss": "^4.1.10"
   }
 }

--- a/omnibox/apps/web/postcss.config.cjs
+++ b/omnibox/apps/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+};

--- a/omnibox/apps/web/tailwind.config.cjs
+++ b/omnibox/apps/web/tailwind.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add Tailwind and PostCSS dev dependencies
- configure Tailwind and PostCSS in the web app
- include Tailwind directives in global styles
- style dashboard page with modern flexbox chat layout

## Testing
- `pnpm --filter web build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c07ad565c832a9e183e5a66ac252e