### PR TITLE
Improve chat dashboard UI

### DIFF
--- a/omnibox/apps/web/app/dashboard/page.tsx
+++ b/omnibox/apps/web/app/dashboard/page.tsx
@@ -1,50 +1,66 @@
 "use client";
 
 import useSWR from "swr";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 // Robust fetcher handles non-JSON gracefully
 const fetcher = async (url: string) => {
-  const res = await fetch(url)
-  const text = await res.text()
+  const res = await fetch(url);
+  const text = await res.text();
   console.log(`Fetcher got for ${url}:`, text); // <--- ADDED LOGGING
   try {
-    return JSON.parse(text)
+    return JSON.parse(text);
   } catch {
-    return { error: text }
+    return { error: text };
   }
-}
+};
 
 export default function Dashboard() {
   // contacts for the signed-in user
-  const { data: contacts, error: contactsError } = useSWR('/api/contacts', fetcher)
-  const [contactId, setContactId] = useState<string>()
+  const { data: contacts, error: contactsError } = useSWR(
+    "/api/contacts",
+    fetcher,
+  );
+  const [contactId, setContactId] = useState<string>();
 
   // messages for the selected contact
-  const { data: messages, error: messagesError, mutate: mutateMessages } = useSWR(
+  const {
+    data: messages,
+    error: messagesError,
+    mutate: mutateMessages,
+  } = useSWR(
     contactId ? `/api/messages?contactId=${contactId}` : null,
-    fetcher
-  )
+    fetcher,
+  );
 
   // State for the new outbound message
-  const [messageBody, setMessageBody] = useState("")
+  const [messageBody, setMessageBody] = useState("");
 
   // Handler for sending a message
   async function sendMessage(e: React.FormEvent) {
-    e.preventDefault()
-    if (!contactId || !messageBody.trim()) return
+    e.preventDefault();
+    if (!contactId || !messageBody.trim()) return;
     const res = await fetch("/api/messages", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ contactId, body: messageBody }),
-    })
+    });
     if (res.ok) {
-      setMessageBody("")
-      if (mutateMessages) mutateMessages()
+      setMessageBody("");
+      if (mutateMessages) mutateMessages();
     }
   }
 
-  const selectedContact = contacts?.contacts?.find((c: any) => c.id === contactId)
+  const selectedContact = contacts?.contacts?.find(
+    (c: any) => c.id === contactId,
+  );
+
+  const uniqueContacts = useMemo(() => {
+    if (!contacts?.contacts) return [] as any[];
+    return Array.from(
+      new Map(contacts.contacts.map((c: any) => [c.id, c])).values(),
+    );
+  }, [contacts]);
 
   const contactInitials = selectedContact?.name
     ? selectedContact.name
@@ -53,43 +69,48 @@ export default function Dashboard() {
         .join("")
         .slice(0, 2)
         .toUpperCase()
-    : "?"
+    : "?";
 
   const Avatar = ({ label }: { label: string }) => (
     <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-300 text-xs font-medium text-gray-700">
       {label}
     </div>
-  )
+  );
 
   return (
-    <div className="flex flex-col gap-6 p-6 sm:flex-row h-[calc(100vh-3rem)]">
+    <div className="flex h-screen flex-col gap-4 bg-gray-50 p-4 sm:flex-row overflow-hidden">
       {/* CONTACT LIST */}
-      <aside className="flex-shrink-0 sm:w-64 border-gray-200 sm:border-r overflow-y-auto">
-        <h2 className="px-2 pb-2 text-lg font-semibold">Contacts</h2>
+      <aside className="flex-shrink-0 overflow-y-auto sm:w-64 sm:border-r sm:border-gray-200 pr-4 sm:pr-0">
+        <h2 className="px-2 pb-3 text-lg font-semibold">Contacts</h2>
         {contactsError && (
           <div className="mb-2 px-2 text-red-500">
-            Error loading contacts: {contactsError.message || String(contactsError)}
+            Error loading contacts:{" "}
+            {contactsError.message || String(contactsError)}
           </div>
         )}
-        <ul className="space-y-1 px-2 pb-4">
-          {contacts?.contacts?.map((c: any) => (
+        <ul className="space-y-1 px-2 pb-4 text-sm">
+          {uniqueContacts.map((c: any) => (
             <li key={c.id}>
               <button
-                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left hover:bg-gray-100 ${
-                  c.id === contactId ? 'bg-gray-200 font-medium' : ''
+                className={`flex w-full items-center gap-2 rounded px-3 py-2 text-left hover:bg-gray-100 focus:outline-none ${
+                  c.id === contactId
+                    ? "bg-blue-100 text-blue-700 font-medium"
+                    : ""
                 }`}
                 onClick={() => setContactId(c.id)}
               >
-                <Avatar label={
-                  c.name
-                    ? c.name
-                        .split(' ')
-                        .map((p: string) => p[0])
-                        .join('')
-                        .slice(0, 2)
-                        .toUpperCase()
-                    : '?'
-                } />
+                <Avatar
+                  label={
+                    c.name
+                      ? c.name
+                          .split(" ")
+                          .map((p: string) => p[0])
+                          .join("")
+                          .slice(0, 2)
+                          .toUpperCase()
+                      : "?"
+                  }
+                />
                 <span className="truncate">{c.name || c.email || c.phone}</span>
               </button>
             </li>
@@ -98,7 +119,7 @@ export default function Dashboard() {
       </aside>
 
       {/* MESSAGE THREAD */}
-      <main className="flex h-full flex-1 flex-col">
+      <main className="relative flex h-full flex-1 flex-col overflow-hidden rounded-lg bg-white shadow">
         {!contactId && (
           <div className="flex flex-1 items-center justify-center text-gray-500">
             Select a contact
@@ -107,25 +128,37 @@ export default function Dashboard() {
         {contactId && (
           <>
             <div className="border-b border-gray-200 px-4 py-2 font-semibold">
-              {selectedContact?.name || selectedContact?.email || selectedContact?.phone}
+              {selectedContact?.name ||
+                selectedContact?.email ||
+                selectedContact?.phone}
             </div>
             {messagesError && (
               <div className="mb-2 px-4 text-red-500">
-                Error loading messages: {messagesError.message || String(messagesError)}
+                Error loading messages:{" "}
+                {messagesError.message || String(messagesError)}
               </div>
             )}
-            <ul className="flex-1 space-y-3 overflow-y-auto p-4">
+            <ul className="flex-1 space-y-4 overflow-y-auto p-4 scrollbar-thin">
               {messages?.messages?.map((m: any) => (
-                <li key={m.id} className={`flex ${m.direction === 'OUT' ? 'justify-end' : 'justify-start'}`}>
-                  <div className={`flex items-end gap-2 ${m.direction === 'OUT' ? 'flex-row-reverse' : ''}`}>
-                    <Avatar label={m.direction === 'OUT' ? 'You' : contactInitials} />
+                <li
+                  key={m.id}
+                  className={`flex ${m.direction === "OUT" ? "justify-end" : "justify-start"}`}
+                >
+                  <div
+                    className={`flex items-end gap-2 ${m.direction === "OUT" ? "flex-row-reverse" : ""}`}
+                  >
+                    <Avatar
+                      label={m.direction === "OUT" ? "You" : contactInitials}
+                    />
                     <div
-                      className={`max-w-[70%] break-words rounded-lg px-3 py-2 text-sm ${
-                        m.direction === 'OUT' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'
+                      className={`max-w-[60%] break-words rounded-lg px-3 py-2 text-sm ${
+                        m.direction === "OUT"
+                          ? "bg-blue-600 text-white"
+                          : "bg-gray-100 text-gray-900"
                       }`}
                     >
                       <p>{m.body}</p>
-                      <span className="mt-1 block text-[10px] text-gray-500">
+                      <span className="mt-1 block text-xs text-gray-500">
                         {new Date(m.sentAt).toLocaleString()}
                       </span>
                     </div>
@@ -133,7 +166,10 @@ export default function Dashboard() {
                 </li>
               ))}
             </ul>
-            <form onSubmit={sendMessage} className="flex gap-2 border-t border-gray-200 p-4">
+            <form
+              onSubmit={sendMessage}
+              className="sticky bottom-0 left-0 right-0 flex gap-2 border-t border-gray-200 bg-white p-4"
+            >
               <input
                 className="flex-1 rounded border px-3 py-2"
                 placeholder="Type a message…"
@@ -154,5 +190,5 @@ export default function Dashboard() {
         )}
       </main>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- redesign dashboard layout with a sidebar and main chat pane
- highlight selected contact and deduplicate contacts
- show chat messages as colored bubbles
- keep the compose box fixed at the bottom of the chat

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c18da1c58832aa4d1c8f0f8fa06b0