### PR TITLE
Fix message creation to store userId

### DIFF
--- a/omnibox/apps/web/lib/webhooks.ts
+++ b/omnibox/apps/web/lib/webhooks.ts
@@ -38,6 +38,7 @@ export async function upsertContactAndMessage(
 
   const message = await prisma.message.create({
     data: {
+      userId: user.id,
       contactId: contact.id,
       provider,
       body,


### PR DESCRIPTION
## Summary
- include `userId` when creating messages via the webhook

## Testing
- `pnpm --filter web build`

------
https://chatgpt.com/codex/tasks/task_e_684c20203d2c832abdcab8c4dd29935d