### PR TITLE
Fix missing stylesheet import with Tailwind

### DIFF
--- a/omnibox/apps/web/app/page.tsx
+++ b/omnibox/apps/web/app/page.tsx
@@ -1,6 +1,6 @@
 import Image, { type ImageProps } from "next/image";
 import { Button } from "@repo/ui/button";
-import styles from "./page.module.css";
+
 
 type Props = Omit<ImageProps, "src"> & {
   srcLight: string;
@@ -20,10 +20,13 @@ const ThemeImage = (props: Props) => {
 
 export default function Home() {
   return (
-    <div className={styles.page}>
-      <main className={styles.main}>
+    <div
+      className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 md:p-20"
+    >
+      <main className="row-start-2 flex flex-col items-center gap-8 md:items-start">
+        {/* Logo with dark mode inversion */}
         <ThemeImage
-          className={styles.logo}
+          className="dark:invert"
           srcLight="turborepo-dark.svg"
           srcDark="turborepo-light.svg"
           alt="Turborepo logo"
@@ -31,43 +34,46 @@ export default function Home() {
           height={38}
           priority
         />
-        <ol>
+        <ol className="list-inside space-y-2 text-sm leading-6 md:text-left text-center font-mono">
           <li>
-            Get started by editing <code>apps/web/app/page.tsx</code>
+            Get started by editing <code className="rounded bg-gray-100 px-1 py-0.5 font-semibold dark:bg-gray-800">apps/web/app/page.tsx</code>
           </li>
           <li>Save and see your changes instantly.</li>
         </ol>
 
-        <div className={styles.ctas}>
+        <div className="flex flex-col gap-4 sm:flex-row">
           <a
-            className={styles.primary}
+            className="inline-flex items-center gap-2 rounded-full bg-gray-900 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-700 dark:bg-white dark:text-black dark:hover:bg-gray-300"
             href="https://vercel.com/new/clone?demo-description=Learn+to+implement+a+monorepo+with+a+two+Next.js+sites+that+has+installed+three+local+packages.&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4K8ZISWAzJ8X1504ca0zmC%2F0b21a1c6246add355e55816278ef54bc%2FBasic.png&demo-title=Monorepo+with+Turborepo&demo-url=https%3A%2F%2Fexamples-basic-web.vercel.sh%2F&from=templates&project-name=Monorepo+with+Turborepo&repository-name=monorepo-turborepo&repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fturborepo%2Ftree%2Fmain%2Fexamples%2Fbasic&root-directory=apps%2Fdocs&skippable-integrations=1&teamSlug=vercel&utm_source=create-turbo"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <Image
-              className={styles.logo}
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            href="https://turborepo.com/docs?utm_source"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.secondary}
-          >
-            Read our docs
-          </a>
-        </div>
-        <Button appName="web" className={styles.secondary}>
-          Open alert
-        </Button>
-      </main>
-      <footer className={styles.footer}>
+          <Image
+            className="dark:invert"
+            src="/vercel.svg"
+            alt="Vercel logomark"
+            width={20}
+            height={20}
+          />
+          Deploy now
+        </a>
+        <a
+          href="https://turborepo.com/docs?utm_source"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center rounded-full border border-gray-300 px-5 py-3 text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+        >
+          Read our docs
+        </a>
+      </div>
+      <Button
+        appName="web"
+        className="inline-flex items-center justify-center rounded-full border border-gray-300 px-5 py-3 text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+      >
+        Open alert
+      </Button>
+    </main>
+    <footer className="row-start-3 flex flex-wrap items-center justify-center gap-6">
         <a
           href="https://vercel.com/templates?search=turborepo&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
           target="_blank"


### PR DESCRIPTION
## Summary
- drop CSS module import from `page.tsx`
- use Tailwind classes for the landing page layout

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm check-types` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_684c460db144832a83b3d8a63ee4a1c0