### PR TITLE
Remove shadcn-ui import from layout and add to global CSS

### DIFF
--- a/omnibox/apps/web/app/globals.css
+++ b/omnibox/apps/web/app/globals.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import "shadcn-ui-react/dist/style.css";
 
 :root {
   --background: #ffffff;

--- a/omnibox/apps/web/app/layout.tsx
+++ b/omnibox/apps/web/app/layout.tsx
@@ -1,5 +1,4 @@
 import "./globals.css";
-import "shadcn-ui-react/dist/style.css";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 


### PR DESCRIPTION
## Summary
- remove shadcn-ui style import from `layout.tsx`
- import the style in `globals.css` after the Tailwind directives

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ENETUNREACH at connect to 104.16.29.34:443)*

------
https://chatgpt.com/codex/tasks/task_e_6850178ba3b0832aa05b58d93f180aa8