### PR TITLE
Update layout links

### DIFF
--- a/omnibox/apps/web/app/dashboard/layout.tsx
+++ b/omnibox/apps/web/app/dashboard/layout.tsx
@@ -7,15 +7,15 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
     <div className="flex min-h-screen">
       <aside className="w-48 border-r p-4 space-y-2">
         <nav className="flex flex-col gap-2">
-          <Link href="/dashboard/inbox">
-            <Button variant="ghost" className="w-full justify-start">Inbox</Button>
-          </Link>
-          <Link href="/dashboard/deals">
-            <Button variant="ghost" className="w-full justify-start">Deals</Button>
-          </Link>
-          <Link href="/dashboard/settings">
-            <Button variant="ghost" className="w-full justify-start">Settings</Button>
-          </Link>
+          <Button variant="ghost" className="w-full justify-start" asChild>
+            <Link href="/dashboard/inbox">Inbox</Link>
+          </Button>
+          <Button variant="ghost" className="w-full justify-start" asChild>
+            <Link href="/dashboard/deals">Deals</Link>
+          </Button>
+          <Button variant="ghost" className="w-full justify-start" asChild>
+            <Link href="/dashboard/settings">Settings</Link>
+          </Button>
         </nav>
       </aside>
       <main className="flex-1 p-4 overflow-y-auto">{children}</main>


### PR DESCRIPTION
## Summary
- refactor dashboard layout navigation buttons to use the `asChild` variant for links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850178e5a9c832a9b1ca38217ba996b