### PR TITLE
Fix Tailwind stylesheet import

### DIFF
--- a/omnibox/apps/web/postcss.config.cjs
+++ b/omnibox/apps/web/postcss.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    'postcss-import': {},
     tailwindcss: {},
     autoprefixer: {},
   },


### PR DESCRIPTION
## Summary
- include `postcss-import` so Tailwind can process shadcn-ui-react styles

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502908750c832a888675ffe289de82