### PR TITLE
Add avatar support and enhance client tags

### DIFF
--- a/omnibox/apps/web/app/api/client/[id]/route.ts
+++ b/omnibox/apps/web/app/api/client/[id]/route.ts
@@ -2,35 +2,58 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
-  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const user = await prisma.user.findFirst({
+    where: { email },
+    select: { id: true },
+  });
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await req.json();
-  const { name, email: clientEmail, phone, company, notes, tag } = body as {
+  const {
+    name,
+    email: clientEmail,
+    phone,
+    company,
+    notes,
+    tag,
+    avatar,
+  } = body as {
     name?: string;
     email?: string;
     phone?: string;
     company?: string;
     notes?: string;
     tag?: string;
+    avatar?: string;
   };
 
   const client = await prisma.contact.update({
     where: { id: params.id, userId: user.id },
-    data: { name, email: clientEmail, phone, company, notes, tag },
+    data: { name, email: clientEmail, phone, company, notes, tag, avatar },
   });
 
   return NextResponse.json({ client });
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
-  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const user = await prisma.user.findFirst({
+    where: { email },
+    select: { id: true },
+  });
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   await prisma.contact.delete({ where: { id: params.id, userId: user.id } });
 

--- a/omnibox/apps/web/app/api/clients/route.ts
+++ b/omnibox/apps/web/app/api/clients/route.ts
@@ -5,7 +5,10 @@ import { serverSession } from "@/lib/auth";
 export async function GET() {
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
-  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+  const user = await prisma.user.findFirst({
+    where: { email },
+    select: { id: true },
+  });
   if (!user) return NextResponse.json({ clients: [] });
 
   const clients = await prisma.contact.findMany({
@@ -18,13 +21,18 @@ export async function GET() {
       company: true,
       notes: true,
       tag: true,
+      avatar: true,
       createdAt: true,
-      messages: { orderBy: { sentAt: "desc" }, take: 1, select: { sentAt: true } },
+      messages: {
+        orderBy: { sentAt: "desc" },
+        take: 1,
+        select: { sentAt: true },
+      },
     },
     orderBy: { name: "asc" },
   });
 
-  const result = clients.map(c => ({
+  const result = clients.map((c) => ({
     ...c,
     lastActivity: c.messages[0]?.sentAt ?? c.createdAt,
   }));
@@ -35,21 +43,43 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
-  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const user = await prisma.user.findFirst({
+    where: { email },
+    select: { id: true },
+  });
+  if (!user)
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await req.json();
-  const { name, email: clientEmail, phone, company, notes, tag } = body as {
+  const {
+    name,
+    email: clientEmail,
+    phone,
+    company,
+    notes,
+    tag,
+    avatar,
+  } = body as {
     name?: string;
     email?: string;
     phone?: string;
     company?: string;
     notes?: string;
     tag?: string;
+    avatar?: string;
   };
 
   const client = await prisma.contact.create({
-    data: { userId: user.id, name, email: clientEmail, phone, company, notes, tag },
+    data: {
+      userId: user.id,
+      name,
+      email: clientEmail,
+      phone,
+      company,
+      notes,
+      tag,
+      avatar,
+    },
   });
 
   return NextResponse.json({ client }, { status: 201 });

--- a/omnibox/apps/web/app/dashboard/clients/page.tsx
+++ b/omnibox/apps/web/app/dashboard/clients/page.tsx
@@ -253,6 +253,7 @@ export default function ClientsPage() {
                       <Badge
                         style={{
                           background: tags.find((t) => t.name === c.tag)?.color,
+                          color: "#fff",
                         }}
                       >
                         {c.tag}

--- a/omnibox/apps/web/components/tag-manager.tsx
+++ b/omnibox/apps/web/components/tag-manager.tsx
@@ -41,7 +41,13 @@ export function TagManager({
               value={t.color}
               onChange={(e) => updateTag(t.id, { color: e.target.value })}
             />
-            <button onClick={() => deleteTag(t.id)} className="text-red-600">
+            <button
+              onClick={() => {
+                if (confirm(`Delete tag '${t.name}'?`)) deleteTag(t.id);
+              }}
+              className="text-red-600"
+              aria-label={`Delete tag ${t.name}`}
+            >
               ✕
             </button>
           </div>

--- a/omnibox/apps/web/components/ui.tsx
+++ b/omnibox/apps/web/components/ui.tsx
@@ -62,17 +62,17 @@ export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
 
 export const Badge = ({
   className = "",
+  style,
   children,
 }: {
   className?: string;
+  style?: React.CSSProperties;
   children: React.ReactNode;
 }) => {
   return (
     <span
-      className={
-        "rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-800 " +
-        className
-      }
+      style={style}
+      className={"rounded-full px-2 py-0.5 text-xs " + className}
     >
       {children}
     </span>

--- a/omnibox/prisma/migrations/20250618120000_add_contact_avatar/migration.sql
+++ b/omnibox/prisma/migrations/20250618120000_add_contact_avatar/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Contact" ADD COLUMN "avatar" TEXT;

--- a/omnibox/prisma/schema.prisma
+++ b/omnibox/prisma/schema.prisma
@@ -51,6 +51,7 @@ model Contact {
   company  String?
   notes    String?
   tag      String?
+  avatar   String?
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now())
   messages Message[]


### PR DESCRIPTION
## Summary
- allow deleting tags with confirmation in TagManager
- adjust badge to use custom colors
- include avatar field in contact schema and API routes
- display tag colors correctly on client cards
- clean up detail dialog overlay

## Testing
- `pnpm -C apps/web lint` *(fails: max warnings)*
- `pnpm -C apps/web build` *(fails: lint warnings cause build failure)*

------
https://chatgpt.com/codex/tasks/task_e_6852766b8708832a920993d326259da8