### PR TITLE
Update button styles on clients page

### DIFF
--- a/omnibox/apps/web/app/dashboard/clients/page.tsx
+++ b/omnibox/apps/web/app/dashboard/clients/page.tsx
@@ -214,7 +214,11 @@ export default function ClientsPage() {
               </option>
             ))}
           </select>
-          <Button type="button" onClick={() => setShowTags(true)}>
+          <Button
+            type="button"
+            onClick={() => setShowTags(true)}
+            className="hover:bg-gray-100"
+          >
             Manage Tags
           </Button>
         </div>
@@ -227,7 +231,7 @@ export default function ClientsPage() {
           </Button>
           <Button
             onClick={openAdd}
-            className="whitespace-nowrap border-green-700 bg-green-600 text-white hover:bg-green-700"
+            className="whitespace-nowrap border-green-700 bg-green-600 text-white hover:bg-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
           >
             Add Client
           </Button>
@@ -256,7 +260,7 @@ export default function ClientsPage() {
           <span>No clients yet.</span>
           <Button
             onClick={openAdd}
-            className="border-green-700 bg-green-600 text-white hover:bg-green-700"
+            className="border-green-700 bg-green-600 text-white hover:bg-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
           >
             Add your first client
           </Button>
@@ -435,7 +439,7 @@ export default function ClientsPage() {
               </Button>
               <Button
                 type="submit"
-                className="border-green-700 bg-green-600 text-white hover:bg-green-700"
+                className="border-green-700 bg-green-600 text-white hover:bg-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
               >
                 Save
               </Button>
@@ -530,7 +534,7 @@ export default function ClientsPage() {
               </Button>
               <Button
                 type="button"
-                className="border-green-700 bg-green-600 text-white hover:bg-green-700"
+                className="border-green-700 bg-green-600 text-white hover:bg-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
                 onClick={async () => {
                   await fetch(`/api/client/${detail.id}`, {
                     method: "PATCH",


### PR DESCRIPTION
## Summary
- tweak Manage Tags button styles
- add accessible styles for Add Client buttons
- style Save and Save Notes actions

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685296c024e4832a82a824b6feb8efcb