### PR TITLE
Fix deals page crash on missing extra data

### DIFF
--- a/omnibox/apps/web/app/dashboard/deals/page.tsx
+++ b/omnibox/apps/web/app/dashboard/deals/page.tsx
@@ -78,7 +78,7 @@ function DraggableCard({
       />
       <div className="text-sm font-semibold">Deal {deal.id.slice(0, 4)}</div>
       <div className="text-xs text-gray-600">{deal.contact.name || "Unnamed"}</div>
-      <div className="text-xs text-gray-500">Value: ${extra.value}</div>
+      <div className="text-xs text-gray-500">Value: ${extra?.value ?? 0}</div>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- guard against undefined extras in Deals page

## Testing
- `pnpm lint --filter web` *(fails: turbo not found)*
- `pnpm check-types --filter web` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a61697a8832ab191289570e6f9ae