### PR TITLE
Fix deals page extras tag undefined

### DIFF
--- a/omnibox/apps/web/app/dashboard/deals/page.tsx
+++ b/omnibox/apps/web/app/dashboard/deals/page.tsx
@@ -89,7 +89,7 @@ function DraggableCard({
         {deal.contact.name || "Unnamed"}
       </div>
       <div className="text-xs text-gray-500">Value: ${extra?.value ?? 0}</div>
-      {extra.tag && (
+      {extra?.tag && (
         <span
           className="inline-block rounded-full px-2 py-0.5 text-[10px] text-white"
           style={{


### PR DESCRIPTION
## Summary
- fix crash when extras aren't loaded

## Testing
- `pnpm install`
- `npm run lint` *(fails: ENETUNREACH)*
- `npm run check-types` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6852af076860832a84d2bb9d7245e838