### PR TITLE
Improve deals board customization

### DIFF
--- a/omnibox/apps/web/app/dashboard/clients/page.tsx
+++ b/omnibox/apps/web/app/dashboard/clients/page.tsx
@@ -6,13 +6,7 @@ import { Input, Button, Card, Avatar, Badge, Textarea } from "@/components/ui";
 import { toast } from "sonner";
 import { useTags } from "@/components/tags-context";
 import { TagManager } from "@/components/tag-manager";
-import {
-  Edit3,
-  Trash,
-  Mail,
-  Phone,
-  MessageCircle,
-} from "lucide-react";
+import { Edit3, Trash, Mail, Phone, MessageCircle } from "lucide-react";
 
 const fetcher = async (url: string) => {
   const res = await fetch(url);
@@ -56,7 +50,7 @@ export default function ClientsPage() {
     "/api/clients",
     fetcher,
   );
-  const { tags } = useTags();
+  const { tags } = useTags("clients");
   const [showModal, setShowModal] = useState(false);
   const [detail, setDetail] = useState<Client | null>(null);
   const [form, setForm] = useState({
@@ -472,13 +466,9 @@ export default function ClientsPage() {
             <p className="text-sm text-gray-600">{detail.company}</p>
 
             {(() => {
-              const list = deals?.deals?.filter(
-                (d) => d.contactId === detail.id,
-              ) ?? [];
-              const total = list.reduce(
-                (sum, d) => sum + (d.value ?? 0),
-                0,
-              );
+              const list =
+                deals?.deals?.filter((d) => d.contactId === detail.id) ?? [];
+              const total = list.reduce((sum, d) => sum + (d.value ?? 0), 0);
               return (
                 <div className="space-y-2">
                   <h3 className="mt-2 font-semibold">Deals</h3>
@@ -493,9 +483,7 @@ export default function ClientsPage() {
                           className="flex justify-between border-b py-1"
                         >
                           <span>{d.title || `Deal ${d.id.slice(0, 4)}`}</span>
-                          <span>
-                            {d.value != null ? `$${d.value}` : "N/A"}
-                          </span>
+                          <span>{d.value != null ? `$${d.value}` : "N/A"}</span>
                         </li>
                       ))}
                       <li className="flex justify-between font-semibold">
@@ -587,7 +575,11 @@ export default function ClientsPage() {
         </dialog>
       )}
 
-      <TagManager open={showTags} onClose={() => setShowTags(false)} />
+      <TagManager
+        type="clients"
+        open={showTags}
+        onClose={() => setShowTags(false)}
+      />
     </div>
   );
 }

--- a/omnibox/apps/web/components/tag-manager.tsx
+++ b/omnibox/apps/web/components/tag-manager.tsx
@@ -6,11 +6,13 @@ import { Button, Input } from "./ui";
 export function TagManager({
   open,
   onClose,
+  type = "clients",
 }: {
   open: boolean;
   onClose: () => void;
+  type?: "clients" | "deals";
 }) {
-  const { tags, addTag, updateTag, deleteTag } = useTags();
+  const { tags, addTag, updateTag, deleteTag } = useTags(type);
   const [name, setName] = useState("");
   const [color, setColor] = useState("#60a5fa");
   if (!open) return null;


### PR DESCRIPTION
## Summary
- support separate tags for clients and deals
- allow renaming pipeline columns and adding new ones
- add title and deadline fields to deals
- style save button in drawer

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm --filter web run check-types` *(fails: packages not installed)*
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_e_6852b1afcb88832aad32d5bb46d95d66