### PR TITLE
Fix misordered hooks in deals page

### DIFF
--- a/omnibox/apps/web/app/dashboard/deals/page.tsx
+++ b/omnibox/apps/web/app/dashboard/deals/page.tsx
@@ -187,7 +187,6 @@ export default function DealsPage() {
   useEffect(() => {
     setMounted(true);
   }, []);
-  if (!mounted) return null;
   const [stages, setStages] = useState<Stage[]>(() => {
     if (typeof window === "undefined")
       return [
@@ -407,6 +406,8 @@ export default function DealsPage() {
     toast.success("Deal saved");
     setDrawerDeal(null);
   }
+
+  if (!mounted) return null;
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## Summary
- ensure stable hook order in the Deals page by moving mounted check below hooks

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bbf4e7e4832a8e8b6153972595db