### PR TITLE
Fix undefined drawerDeal in deals page

### DIFF
--- a/omnibox/apps/web/app/dashboard/deals/page.tsx
+++ b/omnibox/apps/web/app/dashboard/deals/page.tsx
@@ -165,6 +165,7 @@ function StageColumn({
   selected,
   toggleSelect,
   openDeal,
+  drawerDeal,
 }: {
   stage: string;
   name: string;
@@ -175,6 +176,7 @@ function StageColumn({
   selected: Set<string>;
   toggleSelect: (id: string, checked: boolean) => void;
   openDeal: (d: Deal) => void;
+  drawerDeal: Deal | null;
 }) {
   const { isOver, setNodeRef } = useDroppable({ id: stage, data: { stage } });
   const [editing, setEditing] = useState(false);
@@ -694,6 +696,7 @@ export default function DealsPage() {
                   })
                 }
                 openDeal={(d) => setDrawerDeal(d)}
+                drawerDeal={drawerDeal}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- pass the current drawer deal into `StageColumn`
- mark the prop and use it when rendering `DraggableCard`

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm --filter web run check-types` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852cac52e68832a83c5b9498b5b20a1