### PR TITLE
Update deals page interactions

### DIFF
--- a/omnibox/apps/web/app/api/deals/route.ts
+++ b/omnibox/apps/web/app/api/deals/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
   const deals = await prisma.deal.findMany({
     where: { userId: user.id },
     include: {
-      contact: { select: { name: true } },
+      contact: { select: { id: true, name: true } },
     },
   });
 


### PR DESCRIPTION
## Summary
- allow editing client name in deal drawer
- show value label in deal drawer
- remove unused close date field
- add drag handle to column headers
- center Add Deal dialog and support deal title entry
- expose contact id from deals API

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm check-types` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d186830c832aa22158b3ef63d606