### PR TITLE
Fix client route deletion

### DIFF
--- a/omnibox/apps/web/app/api/client/[id]/route.ts
+++ b/omnibox/apps/web/app/api/client/[id]/route.ts
@@ -35,9 +35,10 @@ export async function PATCH(
     avatar?: string;
   };
 
+  const { id } = await params;
   try {
     const client = await prisma.contact.update({
-      where: { id: params.id, userId: user.id },
+      where: { id, userId: user.id },
       data: { name, email: clientEmail, phone, company, notes, tag, avatar },
     });
 
@@ -69,7 +70,9 @@ export async function DELETE(
   if (!user)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  await prisma.contact.delete({ where: { id: params.id, userId: user.id } });
+  const { id } = await params;
+  await prisma.deal.deleteMany({ where: { contactId: id, userId: user.id } });
+  await prisma.contact.delete({ where: { id, userId: user.id } });
 
   return NextResponse.json({});
 }


### PR DESCRIPTION
## Summary
- await route params before using them
- remove related deals when deleting a client

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6853b82638dc832aaf33bbb66426892b