### PR TITLE
Fix modals and require deal title

### DIFF
--- a/omnibox/apps/web/app/dashboard/clients/page.tsx
+++ b/omnibox/apps/web/app/dashboard/clients/page.tsx
@@ -541,9 +541,10 @@ export default function ClientsPage() {
       )}
 
       {confirmDelete && (
-        <dialog
-          open
-          className="fixed inset-0 flex items-center justify-center bg-black/50"
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
           onClick={() => setConfirmDelete(null)}
         >
           <div
@@ -572,7 +573,7 @@ export default function ClientsPage() {
               </Button>
             </div>
           </div>
-        </dialog>
+        </div>
       )}
 
       <TagManager

--- a/omnibox/apps/web/app/dashboard/deals/page.tsx
+++ b/omnibox/apps/web/app/dashboard/deals/page.tsx
@@ -503,7 +503,7 @@ export default function DealsPage() {
 
   async function addDeal(e: React.FormEvent) {
     e.preventDefault();
-    if (!contactId) return;
+    if (!contactId || !newTitle) return;
     const res = await fetch("/api/deals", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -878,6 +878,7 @@ export default function DealsPage() {
               placeholder="Title"
               value={newTitle}
               onChange={(e) => setNewTitle(e.target.value)}
+              required
             />
             <select
               className="w-full rounded border p-1"
@@ -895,7 +896,7 @@ export default function DealsPage() {
               <Button type="button" onClick={() => setShowAdd(false)}>
                 Cancel
               </Button>
-              <Button type="submit" disabled={!contactId}>
+              <Button type="submit" disabled={!contactId || !newTitle}>
                 Save
               </Button>
             </div>


### PR DESCRIPTION
## Summary
- require a title when creating a deal
- disable save until a contact and title are chosen
- center the client delete confirmation dialog

## Testing
- `pnpm lint` *(fails: web#lint - warnings treated as errors)*
- `pnpm check-types` *(fails: docs#check-types - cannot find name 'styles')*

------
https://chatgpt.com/codex/tasks/task_e_6853baae9b44832a8fc431eb5fa5b64f