### PR TITLE
Fix missing relation field in Prisma User model

### DIFF
--- a/omnibox/prisma/schema.prisma
+++ b/omnibox/prisma/schema.prisma
@@ -40,23 +40,24 @@ model User {
   contacts       Contact[]
   deals          Deal[]
   stripeCustomer StripeCustomer?
+  quickReplies   QuickReply[]
 }
 
 model Contact {
-  id       String    @id @default(uuid())
-  userId   String
-  phone    String?
-  name     String?
-  email    String?
-  company  String?
-  notes    String?
-  tag      String?
-  avatar   String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now())
-  messages Message[]
-  User     User      @relation(fields: [userId], references: [id])
-  Deal     Deal[]
+  id        String    @id @default(uuid())
+  userId    String
+  phone     String?
+  name      String?
+  email     String?
+  company   String?
+  notes     String?
+  tag       String?
+  avatar    String?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(now())
+  messages  Message[]
+  User      User      @relation(fields: [userId], references: [id])
+  Deal      Deal[]
 
   @@unique([phone, userId], name: "phone_userId")
 }
@@ -136,9 +137,9 @@ model TwilioNumber {
 }
 
 model QuickReply {
-  id     String   @id @default(uuid())
+  id     String @id @default(uuid())
   userId String
   label  String
   text   String
-  user   User     @relation(fields: [userId], references: [id])
+  user   User   @relation(fields: [userId], references: [id])
 }


### PR DESCRIPTION
## Summary
- add missing `QuickReply` relation to `User`

## Testing
- `npx prisma format`
- `npx prisma db push` *(fails: Environment variable not found)*
- `npx prisma generate` *(fails: pnpm add prisma@6.10.1 -D --silent)*
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d474180c832a8b6071a2fad852df