### PR TITLE
Add calendar, message center and segments pages

### DIFF
--- a/omnibox/apps/web/app/dashboard/calendar/page.tsx
+++ b/omnibox/apps/web/app/dashboard/calendar/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+import useSWR from "swr";
+import { useState, useEffect } from "react";
+import { v4 as uuid } from "uuid";
+import { Input, Button, Card } from "@/components/ui";
+
+interface Deal {
+  id: string;
+  contact: { id: string; name: string | null };
+}
+interface DealExtra {
+  title?: string;
+  hasDeadline?: boolean;
+  deadline?: string;
+}
+interface Appointment {
+  id: string;
+  title: string;
+  date: string;
+}
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+};
+
+export default function CalendarPage() {
+  const { data } = useSWR<{ deals: Deal[] }>("/api/deals", fetcher);
+  const [extras, setExtras] = useState<Record<string, DealExtra>>({});
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [title, setTitle] = useState("");
+  const [date, setDate] = useState("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      setExtras(JSON.parse(localStorage.getItem("dealExtras") || "{}"));
+    } catch {}
+    try {
+      setAppointments(JSON.parse(localStorage.getItem("appointments") || "[]"));
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("appointments", JSON.stringify(appointments));
+    }
+  }, [appointments]);
+
+  const events = [
+    ...appointments.map((a) => ({
+      type: "Appointment" as const,
+      title: a.title,
+      date: a.date,
+    })),
+    ...(data?.deals || [])
+      .filter((d) => extras[d.id]?.hasDeadline && extras[d.id]?.deadline)
+      .map((d) => ({
+        type: "Deal Deadline" as const,
+        title: extras[d.id]?.title || d.contact.name || "Deal",
+        date: extras[d.id].deadline!,
+      })),
+  ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  function addAppointment(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title || !date) return;
+    setAppointments((a) => [...a, { id: uuid(), title, date }]);
+    setTitle("");
+    setDate("");
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Calendar</h1>
+      <form onSubmit={addAppointment} className="flex flex-wrap items-end gap-2">
+        <Input
+          className="flex-1"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Appointment title"
+        />
+        <Input
+          type="datetime-local"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <Button type="submit" disabled={!title || !date}
+          >Add</Button>
+      </form>
+      <div className="space-y-2">
+        {events.map((ev, idx) => (
+          <Card key={idx} className="flex items-center justify-between gap-2">
+            <span>{new Date(ev.date).toLocaleString()} – {ev.title}</span>
+            <span className="text-xs text-gray-500">{ev.type}</span>
+          </Card>
+        ))}
+        {events.length === 0 && <p>No events</p>}
+      </div>
+    </div>
+  );
+}

--- a/omnibox/apps/web/app/dashboard/layout.tsx
+++ b/omnibox/apps/web/app/dashboard/layout.tsx
@@ -12,8 +12,17 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
           <Link href="/dashboard/deals" className="w-full rounded px-2 py-1 text-left hover:bg-gray-100">
             Deals
           </Link>
+          <Link href="/dashboard/calendar" className="w-full rounded px-2 py-1 text-left hover:bg-gray-100">
+            Calendar
+          </Link>
           <Link href="/dashboard/clients" className="w-full rounded px-2 py-1 text-left hover:bg-gray-100">
             Clients
+          </Link>
+          <Link href="/dashboard/message-center" className="w-full rounded px-2 py-1 text-left hover:bg-gray-100">
+            Message Center
+          </Link>
+          <Link href="/dashboard/segments" className="w-full rounded px-2 py-1 text-left hover:bg-gray-100">
+            Segments
           </Link>
           <Link href="/dashboard/settings" className="w-full rounded px-2 py-1 text-left hover:bg-gray-100">
             Settings

--- a/omnibox/apps/web/app/dashboard/message-center/page.tsx
+++ b/omnibox/apps/web/app/dashboard/message-center/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Button, Textarea } from "@/components/ui";
+
+interface Segment {
+  id: string;
+  name: string;
+}
+
+export default function MessageCenterPage() {
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      setSegments(JSON.parse(localStorage.getItem("segments") || "[]"));
+    } catch {}
+  }, []);
+
+  function handleSelect(e: React.ChangeEvent<HTMLSelectElement>) {
+    const opts = Array.from(e.target.selectedOptions).map((o) => o.value);
+    setSelected(opts);
+  }
+
+  function send(channel: string) {
+    alert(`Sending ${channel} to ${selected.length} segment(s)`);
+    setMessage("");
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Message Center</h1>
+      <div>
+        <label className="mb-1 block font-medium">Segments</label>
+        <select
+          multiple
+          value={selected}
+          onChange={handleSelect}
+          className="w-full rounded border p-2"
+        >
+          {segments.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <Textarea
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        placeholder="Message…"
+      />
+      <div className="flex gap-2">
+        <Button type="button" onClick={() => send("WhatsApp")}
+          disabled={!message}
+        >
+          Send WhatsApp
+        </Button>
+        <Button type="button" onClick={() => send("Email")}
+          disabled={!message}
+        >
+          Send Email
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/omnibox/apps/web/app/dashboard/segments/page.tsx
+++ b/omnibox/apps/web/app/dashboard/segments/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { useState, useEffect } from "react";
+import { v4 as uuid } from "uuid";
+import { Input, Button, Card } from "@/components/ui";
+
+interface Segment {
+  id: string;
+  name: string;
+}
+
+export default function SegmentsPage() {
+  const [segments, setSegments] = useState<Segment[]>([]);
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      setSegments(JSON.parse(localStorage.getItem("segments") || "[]"));
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("segments", JSON.stringify(segments));
+    }
+  }, [segments]);
+
+  function addSegment(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name) return;
+    setSegments((s) => [...s, { id: uuid(), name }]);
+    setName("");
+  }
+
+  function deleteSegment(id: string) {
+    setSegments((s) => s.filter((seg) => seg.id !== id));
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Segments</h1>
+      <form onSubmit={addSegment} className="flex gap-2">
+        <Input
+          className="flex-1"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Segment name"
+        />
+        <Button type="submit" disabled={!name}>Add</Button>
+      </form>
+      <div className="space-y-2">
+        {segments.map((s) => (
+          <Card key={s.id} className="flex items-center justify-between">
+            <span>{s.name}</span>
+            <Button
+              type="button"
+              className="text-red-600"
+              onClick={() => deleteSegment(s.id)}
+            >
+              Delete
+            </Button>
+          </Card>
+        ))}
+        {segments.length === 0 && <p>No segments</p>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend dashboard sidebar links
- add calendar page
- add message center page
- add segments page

## Testing
- `pnpm lint` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_6853d9aab3a0832a931768b770580e7c