### PR TITLE
Add calendar view selector and green add buttons

### DIFF
--- a/omnibox/apps/web/app/dashboard/calendar/page.tsx
+++ b/omnibox/apps/web/app/dashboard/calendar/page.tsx
@@ -35,6 +35,7 @@ export default function CalendarPage() {
   const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [title, setTitle] = useState("");
   const [date, setDate] = useState("");
+  const [view, setView] = useState<"week" | "month">("week");
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -67,6 +68,23 @@ export default function CalendarPage() {
       })),
   ].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
+  const now = new Date();
+  const startOfWeek = new Date(now);
+  startOfWeek.setDate(now.getDate() - now.getDay());
+  const endOfWeek = new Date(startOfWeek);
+  endOfWeek.setDate(startOfWeek.getDate() + 7);
+
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+  const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+
+  const filteredEvents = events.filter((ev) => {
+    const d = new Date(ev.date);
+    if (view === "week") {
+      return d >= startOfWeek && d < endOfWeek;
+    }
+    return d >= startOfMonth && d <= endOfMonth;
+  });
+
   function addAppointment(e: React.FormEvent) {
     e.preventDefault();
     if (!title || !date) return;
@@ -78,6 +96,18 @@ export default function CalendarPage() {
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">Calendar</h1>
+      <div className="flex items-center gap-2">
+        <label htmlFor="view" className="text-sm">View:</label>
+        <select
+          id="view"
+          value={view}
+          onChange={(e) => setView(e.target.value as "week" | "month")}
+          className="rounded border px-2 py-1"
+        >
+          <option value="week">This week</option>
+          <option value="month">This month</option>
+        </select>
+      </div>
       <form onSubmit={addAppointment} className="flex flex-wrap items-end gap-2">
         <Input
           className="flex-1"
@@ -90,17 +120,21 @@ export default function CalendarPage() {
           value={date}
           onChange={(e) => setDate(e.target.value)}
         />
-        <Button type="submit" disabled={!title || !date}
-          >Add</Button>
+        <Button
+          type="submit"
+          className="bg-green-600 text-white"
+        >
+          Add appointment
+        </Button>
       </form>
       <div className="space-y-2">
-        {events.map((ev, idx) => (
+        {filteredEvents.map((ev, idx) => (
           <Card key={idx} className="flex items-center justify-between gap-2">
             <span>{new Date(ev.date).toLocaleString()} – {ev.title}</span>
             <span className="text-xs text-gray-500">{ev.type}</span>
           </Card>
         ))}
-        {events.length === 0 && <p>No events</p>}
+        {filteredEvents.length === 0 && <p>No events</p>}
       </div>
     </div>
   );

--- a/omnibox/apps/web/app/dashboard/segments/page.tsx
+++ b/omnibox/apps/web/app/dashboard/segments/page.tsx
@@ -46,7 +46,9 @@ export default function SegmentsPage() {
           onChange={(e) => setName(e.target.value)}
           placeholder="Segment name"
         />
-        <Button type="submit" disabled={!name}>Add</Button>
+        <Button type="submit" className="bg-green-600 text-white">
+          Create segment
+        </Button>
       </form>
       <div className="space-y-2">
         {segments.map((s) => (


### PR DESCRIPTION
## Summary
- allow choosing calendar view by week or month
- rename Add button to Add appointment and make it green
- rename Add button in Segments page to Create segment and style green

## Testing
- `pnpm lint` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_6853e675f4f4832abd8a35033bed9313