### PR TITLE
Add calendar grid and modal forms

### DIFF
--- a/omnibox/apps/web/app/dashboard/segments/page.tsx
+++ b/omnibox/apps/web/app/dashboard/segments/page.tsx
@@ -6,11 +6,14 @@ import { Input, Button, Card } from "@/components/ui";
 interface Segment {
   id: string;
   name: string;
+  field: string;
 }
 
 export default function SegmentsPage() {
   const [segments, setSegments] = useState<Segment[]>([]);
   const [name, setName] = useState("");
+  const [field, setField] = useState("phone");
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -28,8 +31,10 @@ export default function SegmentsPage() {
   function addSegment(e: React.FormEvent) {
     e.preventDefault();
     if (!name) return;
-    setSegments((s) => [...s, { id: uuid(), name }]);
+    setSegments((s) => [...s, { id: uuid(), name, field }]);
     setName("");
+    setField("phone");
+    setShowModal(false);
   }
 
   function deleteSegment(id: string) {
@@ -39,25 +44,20 @@ export default function SegmentsPage() {
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">Segments</h1>
-      <form onSubmit={addSegment} className="flex gap-2">
-        <Input
-          className="flex-1"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Segment name"
-        />
-        <Button
-          type="submit"
-          onClick={addSegment}
-          className="bg-green-600 text-white"
-        >
-          Create segment
-        </Button>
-      </form>
+      <Button
+        type="button"
+        onClick={() => setShowModal(true)}
+        className="bg-green-600 text-white"
+      >
+        Create segment
+      </Button>
       <div className="space-y-2">
         {segments.map((s) => (
           <Card key={s.id} className="flex items-center justify-between">
-            <span>{s.name}</span>
+            <span>
+              {s.name}
+              <span className="ml-1 text-xs text-gray-500">({s.field})</span>
+            </span>
             <Button
               type="button"
               className="text-red-600"
@@ -69,6 +69,47 @@ export default function SegmentsPage() {
         ))}
         {segments.length === 0 && <p>No segments</p>}
       </div>
+
+      {showModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur"
+          onClick={() => setShowModal(false)}
+        >
+          <form
+            onSubmit={addSegment}
+            className="w-80 space-y-2 rounded bg-white p-4 shadow"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="font-semibold">New Segment</h2>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Segment name"
+            />
+            <select
+              className="w-full rounded border p-1"
+              value={field}
+              onChange={(e) => setField(e.target.value)}
+            >
+              <option value="phone">Has phone number</option>
+              <option value="email">Has email address</option>
+              <option value="company">Has company</option>
+              <option value="tag">Has tag</option>
+              <option value="notes">Has notes</option>
+            </select>
+            <div className="flex justify-end gap-2">
+              <Button type="button" onClick={() => setShowModal(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" className="bg-green-600 text-white">
+                Save
+              </Button>
+            </div>
+          </form>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show a calendar grid for week/month views
- create appointments in a modal popup
- create segments in a modal popup with field filters

## Testing
- `npx --yes turbo@2.5.4 lint` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685551c67218832aa3436e502b52388e