### PR TITLE
Enhance calendar and inbox UX

### DIFF
--- a/omnibox/apps/web/app/dashboard/inbox/page.tsx
+++ b/omnibox/apps/web/app/dashboard/inbox/page.tsx
@@ -2,7 +2,7 @@
 
 import useSWR from "swr";
 import { useMemo, useState } from "react";
-import { Input, Button, Avatar } from "@/components/ui";
+import { Input, Button, Avatar, Spinner } from "@/components/ui";
 
 // Robust fetcher handles non-JSON gracefully
 const fetcher = async (url: string) => {
@@ -82,8 +82,12 @@ export default function InboxPage() {
         <h2 className="px-2 pb-3 text-lg font-semibold">Contacts</h2>
         {contactsError && (
           <div className="mb-2 px-2 text-red-500">
-            Error loading contacts:{" "}
-            {contactsError.message || String(contactsError)}
+            Error loading contacts: {contactsError.message || String(contactsError)}
+          </div>
+        )}
+        {!contacts && !contactsError && (
+          <div className="flex justify-center py-4">
+            <Spinner />
           </div>
         )}
         <ul className="space-y-1 px-2 pb-4 text-sm">

--- a/omnibox/apps/web/components/ui.tsx
+++ b/omnibox/apps/web/components/ui.tsx
@@ -87,3 +87,33 @@ export const Textarea = forwardRef<
     />
   );
 });
+
+export const Spinner = (
+  props: React.SVGProps<SVGSVGElement> & { label?: string },
+) => {
+  const { label = "Loading...", className = "", ...rest } = props;
+  return (
+    <svg
+      role="status"
+      aria-label={label}
+      className={"h-5 w-5 animate-spin text-gray-500 " + className}
+      viewBox="0 0 24 24"
+      {...rest}
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+        fill="none"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8z"
+      />
+    </svg>
+  );
+};


### PR DESCRIPTION
## Summary
- add generic `Spinner` UI component
- display loading spinner when contacts load
- let calendar appointments store a color
- add color picker to appointment form
- show client name in appointment detail
- confirm before deleting an appointment
- default calendar view is month

## Testing
- `pnpm lint` *(fails: turbo not found / network issues)*
- `pnpm build` *(fails: ENETUNREACH when downloading)*

------
https://chatgpt.com/codex/tasks/task_e_6855685c1628832a9c69be347efa992c