### PR TITLE
Fix calendar hydration mismatch

### DIFF
--- a/omnibox/apps/web/app/dashboard/calendar/page.tsx
+++ b/omnibox/apps/web/app/dashboard/calendar/page.tsx
@@ -243,7 +243,10 @@ export default function CalendarPage() {
           ◀
         </Button>
         <span className="mx-1 font-semibold">
-          {currentDate.toLocaleString("default", { month: "long", year: "numeric" })}
+          {currentDate.toLocaleString("en-US", {
+            month: "long",
+            year: "numeric",
+          })}
         </span>
         <Button type="button" onClick={() => setCurrentDate(new Date(currentDate.getFullYear(), currentDate.getMonth()+1, 1))}>
           ▶
@@ -279,7 +282,7 @@ export default function CalendarPage() {
                 style={{ background: eventColor(ev) }}
               >
                 <span className="truncate text-sm font-medium text-gray-800">
-                  {new Date(ev.date).toLocaleString()} - {ev.title}
+                  {new Date(ev.date).toLocaleString("en-US")} - {ev.title}
                 </span>
               </li>
             ))}
@@ -424,7 +427,7 @@ export default function CalendarPage() {
           >
             <h2 className="font-semibold">{detail.title}</h2>
             <p className="text-sm text-gray-600">
-              {new Date(detail.date).toLocaleString()}
+              {new Date(detail.date).toLocaleString("en-US")}
             </p>
             {detail.clientId && (
               <p className="text-sm">


### PR DESCRIPTION
## Summary
- enforce English date locale on calendar page to avoid hydration mismatch

## Testing
- `pnpm lint` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68556b204adc832aa7c754195f8ceeb9