### PR TITLE
Fix dashboard navigation rendering

### DIFF
--- a/omnibox/apps/web/app/dashboard/layout.tsx
+++ b/omnibox/apps/web/app/dashboard/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { ReactNode } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";


### PR DESCRIPTION
## Summary
- mark the dashboard layout as a client component so `usePathname` works

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH 104.16.31.34)*
- `pnpm check-types` *(fails: connect ENETUNREACH 104.16.25.34)*

------
https://chatgpt.com/codex/tasks/task_e_685b1075e7dc832a8f9b1358e74f8adf