### PR TITLE
Fix lucide icon import error

### DIFF
--- a/omnibox/apps/web/package.json
+++ b/omnibox/apps/web/package.json
@@ -18,7 +18,7 @@
     "@prisma/client": "^6.9.0",
     "@repo/ui": "workspace:*",
     "@sendgrid/mail": "^8.1.5",
-    "lucide-react": "0.270.0",
+    "lucide-react": "0.523.0",
     "next": "^15.3.0",
     "next-auth": "^4.24.11",
     "react": "^19.1.0",

--- a/omnibox/pnpm-lock.yaml
+++ b/omnibox/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: ^5.52.0
         version: 5.81.2(react@19.1.0)
       lucide-react:
-        specifier: 0.270.0
-        version: 0.270.0(react@19.1.0)
+        specifier: 0.523.0
+        version: 0.523.0(react@19.1.0)
       next:
         specifier: ^15.3.0
         version: 15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2442,10 +2442,10 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-  lucide-react@0.270.0:
-    resolution: {integrity: sha512-J8aEhNX6Jx1GiEvvsDONpT1SGOx0DLx7Qj6sJ9TJS3RDP3Ab7vpwXcEG6J0aIRon33iUgEH2c6TFd7B8HTh2SQ==}
+  lucide-react@0.523.0:
+    resolution: {integrity: sha512-rUjQoy7egZT9XYVXBK1je9ckBnNp7qzRZOhLQx5RcEp2dCGlXo+mv6vf7Am4LimEcFBJIIZzSGfgTqc9QCrPSw==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   luxon@1.28.1:
     resolution: {integrity: sha512-gYHAa180mKrNIUJCbwpmD0aTu9kV0dREDrwNnuyFAsO1Wt0EVYSZelPnJlbj9HplzXX/YWXHFTL45kvZ53M0pw==}
@@ -6258,7 +6258,7 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-  lucide-react@0.270.0(react@19.1.0):
+  lucide-react@0.523.0(react@19.1.0):
     dependencies:
       react: 19.1.0
 


### PR DESCRIPTION
## Summary
- update lucide-react so Handshake icon exists

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm check-types` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685b1597b798832aa571c9fa91249c1b