### PR TITLE
Implement basic invoicing

### DIFF
--- a/omnibox/apps/web/app/api/invoice/[id]/route.ts
+++ b/omnibox/apps/web/app/api/invoice/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { serverSession } from '@/lib/auth';
+import sgMail from '@sendgrid/mail';
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY!);
+const EMAIL_FROM = process.env.EMAIL_FROM!;
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await serverSession();
+  let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
+  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await req.json();
+  const { action } = body as { action?: string };
+  const invoice = await prisma.invoice.findFirst({
+    where: { id: params.id, userId: user.id },
+    include: { contact: true },
+  });
+  if (!invoice) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  if (action === 'markPaid') {
+    const updated = await prisma.invoice.update({
+      where: { id: params.id },
+      data: { status: 'PAID' },
+    });
+    return NextResponse.json({ invoice: updated });
+  }
+
+  if (action === 'send') {
+    if (!invoice.contact.email) {
+      return NextResponse.json({ error: 'Contact has no email' }, { status: 400 });
+    }
+    await sgMail.send({
+      to: invoice.contact.email,
+      from: EMAIL_FROM,
+      subject: 'Invoice',
+      text: 'Please see attached invoice.',
+      attachments: [
+        {
+          content: invoice.pdfUrl?.split(',')[1] || '',
+          type: 'application/pdf',
+          filename: 'invoice.pdf',
+          disposition: 'attachment',
+        },
+      ],
+    });
+    const updated = await prisma.invoice.update({
+      where: { id: params.id },
+      data: { status: 'SENT' },
+    });
+    return NextResponse.json({ invoice: updated });
+  }
+
+  return NextResponse.json({ invoice });
+}

--- a/omnibox/apps/web/app/api/invoice/template/route.ts
+++ b/omnibox/apps/web/app/api/invoice/template/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { serverSession } from '@/lib/auth';
+
+export async function GET() {
+  const session = await serverSession();
+  let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
+  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+  if (!user) return NextResponse.json({ template: null });
+
+  const template = await prisma.invoiceTemplate.findFirst({ where: { userId: user.id } });
+  return NextResponse.json({ template });
+}
+
+export async function PATCH(req: NextRequest) {
+  const session = await serverSession();
+  let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
+  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await req.json();
+  const data = {
+    logoUrl: body.logoUrl as string | undefined,
+    header: body.header as string | undefined,
+    body: body.body as string | undefined,
+    footer: body.footer as string | undefined,
+    emailSubject: body.emailSubject as string | undefined,
+    emailBody: body.emailBody as string | undefined,
+  };
+
+  const existing = await prisma.invoiceTemplate.findFirst({ where: { userId: user.id } });
+  let template;
+  if (existing) {
+    template = await prisma.invoiceTemplate.update({ where: { id: existing.id }, data });
+  } else {
+    template = await prisma.invoiceTemplate.create({ data: { ...data, userId: user.id } });
+  }
+
+  return NextResponse.json({ template });
+}

--- a/omnibox/apps/web/app/api/invoices/route.ts
+++ b/omnibox/apps/web/app/api/invoices/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { serverSession } from '@/lib/auth';
+import { generateInvoicePdf } from '@/lib/invoice';
+
+export async function GET() {
+  const session = await serverSession();
+  let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
+  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+  if (!user) return NextResponse.json({ invoices: [] });
+
+  const invoices = await prisma.invoice.findMany({
+    where: { userId: user.id },
+    include: { contact: { select: { name: true, email: true } } },
+    orderBy: { createdAt: 'desc' },
+  });
+  return NextResponse.json({ invoices });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await serverSession();
+  let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
+  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await req.json();
+  const { contactId, amount, dueDate } = body as {
+    contactId: string;
+    amount: number;
+    dueDate: string;
+  };
+  const contact = await prisma.contact.findFirst({
+    where: { id: contactId, userId: user.id },
+    select: { name: true },
+  });
+  if (!contact) return NextResponse.json({ error: 'Contact not found' }, { status: 404 });
+
+  const template = await prisma.invoiceTemplate.findFirst({ where: { userId: user.id } });
+  const pdfBase64 = await generateInvoicePdf({
+    logoUrl: template?.logoUrl || undefined,
+    header: template?.header || undefined,
+    body: template?.body || undefined,
+    footer: template?.footer || undefined,
+    amount,
+    dueDate,
+    clientName: contact.name || 'Client',
+  });
+
+  const invoice = await prisma.invoice.create({
+    data: {
+      userId: user.id,
+      contactId,
+      amount,
+      dueDate: new Date(dueDate),
+      pdfUrl: `data:application/pdf;base64,${pdfBase64}`,
+    },
+  });
+
+  return NextResponse.json({ invoice }, { status: 201 });
+}

--- a/omnibox/apps/web/app/dashboard/invoices/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+import useSWR from "swr";
+import { useState } from "react";
+import { Input, Button, Card } from "@/components/ui";
+import { toast } from "sonner";
+
+interface Invoice {
+  id: string;
+  contactId: string;
+  amount: number;
+  dueDate: string;
+  status: string;
+  pdfUrl?: string;
+  contact: { name: string | null; email: string | null };
+}
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+};
+
+export default function InvoicesPage() {
+  const { data, mutate } = useSWR<{ invoices: Invoice[] }>("/api/invoices", fetcher);
+  const { data: clients } = useSWR<{ clients: { id: string; name: string }[] }>(
+    "/api/clients",
+    fetcher,
+  );
+  const [showModal, setShowModal] = useState(false);
+  const [form, setForm] = useState({ contactId: "", amount: "", dueDate: "" });
+
+  async function saveInvoice(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch("/api/invoices", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contactId: form.contactId,
+        amount: parseFloat(form.amount),
+        dueDate: form.dueDate,
+      }),
+    });
+    if (!res.ok) {
+      toast.error("Failed to create invoice");
+    } else {
+      toast.success("Invoice created");
+      mutate();
+      setShowModal(false);
+    }
+  }
+
+  async function action(id: string, act: string) {
+    const res = await fetch(`/api/invoice/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: act }),
+    });
+    if (!res.ok) {
+      toast.error("Action failed");
+    } else {
+      mutate();
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <Button onClick={() => setShowModal(true)}>New Invoice</Button>
+      </div>
+      {data && data.invoices.length === 0 && (
+        <p className="text-center text-gray-500">No invoices.</p>
+      )}
+      {data && data.invoices.length > 0 && (
+        <div className="space-y-2">
+          {data.invoices.map((inv) => (
+            <Card key={inv.id} className="flex justify-between p-2">
+              <div>
+                <div className="font-semibold">{inv.contact.name || "Unnamed"}</div>
+                <div className="text-sm text-gray-600">
+                  ${inv.amount} due {new Date(inv.dueDate).toLocaleDateString()}
+                </div>
+                <div className="text-sm">Status: {inv.status}</div>
+              </div>
+              <div className="flex items-center gap-2">
+                {inv.status !== "PAID" && (
+                  <Button onClick={() => action(inv.id, "markPaid")}>Mark Paid</Button>
+                )}
+                {inv.status === "DRAFT" && (
+                  <Button onClick={() => action(inv.id, "send")}>Send</Button>
+                )}
+                {inv.pdfUrl && (
+                  <a href={inv.pdfUrl} target="_blank" rel="noreferrer" className="text-blue-600 underline">
+                    PDF
+                  </a>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+      {showModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          onClick={() => setShowModal(false)}
+        >
+          <form
+            onSubmit={saveInvoice}
+            className="w-80 space-y-2 rounded bg-white p-4 shadow"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="font-semibold">New Invoice</h2>
+            <select
+              className="w-full rounded border p-1"
+              value={form.contactId}
+              onChange={(e) => setForm({ ...form, contactId: e.target.value })}
+            >
+              <option value="">Select client</option>
+              {clients?.clients.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+            <Input
+              type="number"
+              placeholder="Amount"
+              value={form.amount}
+              onChange={(e) => setForm({ ...form, amount: e.target.value })}
+            />
+            <Input
+              type="date"
+              value={form.dueDate}
+              onChange={(e) => setForm({ ...form, dueDate: e.target.value })}
+            />
+            <div className="flex justify-end gap-2">
+              <Button type="button" onClick={() => setShowModal(false)}>
+                Cancel
+              </Button>
+              <Button type="submit">Save</Button>
+            </div>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/omnibox/apps/web/app/dashboard/invoices/template/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/template/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+import useSWR from "swr";
+import { useState, useEffect } from "react";
+import { Input, Button } from "@/components/ui";
+import { toast } from "sonner";
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+};
+
+export default function InvoiceTemplatePage() {
+  const { data, mutate } = useSWR<{ template: any }>("/api/invoice/template", fetcher);
+  const [form, setForm] = useState({
+    logoUrl: "",
+    header: "",
+    body: "",
+    footer: "",
+    emailSubject: "",
+    emailBody: "",
+  });
+
+  useEffect(() => {
+    if (data?.template) {
+      setForm({
+        logoUrl: data.template.logoUrl || "",
+        header: data.template.header || "",
+        body: data.template.body || "",
+        footer: data.template.footer || "",
+        emailSubject: data.template.emailSubject || "",
+        emailBody: data.template.emailBody || "",
+      });
+    }
+  }, [data]);
+
+  async function save() {
+    const res = await fetch("/api/invoice/template", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(form),
+    });
+    if (!res.ok) {
+      toast.error("Failed to save template");
+    } else {
+      toast.success("Template saved");
+      mutate();
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Input
+        placeholder="Logo URL"
+        value={form.logoUrl}
+        onChange={(e) => setForm({ ...form, logoUrl: e.target.value })}
+      />
+      <Input
+        placeholder="Header"
+        value={form.header}
+        onChange={(e) => setForm({ ...form, header: e.target.value })}
+      />
+      <Input
+        placeholder="Body"
+        value={form.body}
+        onChange={(e) => setForm({ ...form, body: e.target.value })}
+      />
+      <Input
+        placeholder="Footer"
+        value={form.footer}
+        onChange={(e) => setForm({ ...form, footer: e.target.value })}
+      />
+      <Input
+        placeholder="Email Subject"
+        value={form.emailSubject}
+        onChange={(e) => setForm({ ...form, emailSubject: e.target.value })}
+      />
+      <textarea
+        className="w-full rounded border p-1"
+        placeholder="Email Body"
+        value={form.emailBody}
+        onChange={(e) => setForm({ ...form, emailBody: e.target.value })}
+      />
+      <Button onClick={save}>Save Template</Button>
+    </div>
+  );
+}

--- a/omnibox/apps/web/app/dashboard/layout.tsx
+++ b/omnibox/apps/web/app/dashboard/layout.tsx
@@ -10,6 +10,7 @@ import {
   Handshake,
   Calendar,
   Users,
+  FileText,
   MessageCircle,
   PieChart,
   Settings,
@@ -49,6 +50,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
           <NavLink href="/dashboard/deals" icon={Handshake}>Deals</NavLink>
           <NavLink href="/dashboard/calendar" icon={Calendar}>Calendar</NavLink>
           <NavLink href="/dashboard/clients" icon={Users}>Clients</NavLink>
+          <NavLink href="/dashboard/invoices" icon={FileText}>Invoicing</NavLink>
           <NavLink href="/dashboard/message-center" icon={MessageCircle}>
             Message Center
           </NavLink>

--- a/omnibox/apps/web/lib/invoice.ts
+++ b/omnibox/apps/web/lib/invoice.ts
@@ -1,0 +1,71 @@
+import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
+
+export interface InvoiceData {
+  logoUrl?: string;
+  header?: string;
+  body?: string;
+  footer?: string;
+  amount: number;
+  dueDate: string;
+  clientName: string;
+}
+
+export async function generateInvoicePdf(data: InvoiceData) {
+  const doc = await PDFDocument.create();
+  const page = doc.addPage([595, 842]); // A4
+  const { width } = page.getSize();
+
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  let y = 780;
+
+  if (data.logoUrl) {
+    try {
+      const logoBytes = await fetch(data.logoUrl).then((r) => r.arrayBuffer());
+      const logo = await doc.embedPng(logoBytes);
+      page.drawImage(logo, { x: 50, y, width: 100, height: 50 });
+    } catch {
+      // ignore
+    }
+    y -= 60;
+  }
+
+  if (data.header) {
+    page.drawText(data.header, {
+      x: 50,
+      y,
+      size: 14,
+      font,
+    });
+    y -= 20;
+  }
+
+  page.drawText(`Bill To: ${data.clientName}`, { x: 50, y, size: 12, font });
+  y -= 20;
+  page.drawText(`Amount Due: $${data.amount.toFixed(2)}`, {
+    x: 50,
+    y,
+    size: 12,
+    font,
+  });
+  y -= 20;
+  page.drawText(`Due Date: ${data.dueDate}`, { x: 50, y, size: 12, font });
+  y -= 40;
+
+  if (data.body) {
+    page.drawText(data.body, { x: 50, y, size: 12, font, lineHeight: 14 });
+    y -= 40;
+  }
+
+  if (data.footer) {
+    page.drawText(data.footer, {
+      x: 50,
+      y: 40,
+      size: 10,
+      font,
+      color: rgb(0.5, 0.5, 0.5),
+    });
+  }
+
+  const bytes = await doc.save();
+  return Buffer.from(bytes).toString('base64');
+}

--- a/omnibox/apps/web/package.json
+++ b/omnibox/apps/web/package.json
@@ -28,7 +28,8 @@
     "swr": "^2.3.3",
     "@tanstack/react-query": "^5.52.0",
     "uuid": "^8.3.2",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/omnibox/pnpm-lock.yaml
+++ b/omnibox/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       next-auth:
         specifier: ^4.24.11
         version: 4.24.11(next@15.3.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -836,6 +839,12 @@ packages:
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2697,6 +2706,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   param-case@2.1.1:
     resolution: {integrity: sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==}
 
@@ -2735,6 +2747,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -4223,6 +4238,14 @@ snapshots:
       fastq: 1.19.1
 
   '@panva/hkdf@1.2.1': {}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6547,6 +6570,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   param-case@2.1.1:
     dependencies:
       no-case: 2.3.2
@@ -6583,6 +6608,13 @@ snapshots:
       minipass: 7.1.2
 
   path-type@4.0.0: {}
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   peberminta@0.9.0: {}
 

--- a/omnibox/prisma/migrations/20250619090000_add_invoice/migration.sql
+++ b/omnibox/prisma/migrations/20250619090000_add_invoice/migration.sql
@@ -1,0 +1,40 @@
+-- AddEnum
+CREATE TYPE "InvoiceStatus" AS ENUM ('DRAFT', 'SENT', 'PAID');
+
+-- CreateTable
+CREATE TABLE "Invoice" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "contactId" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "dueDate" TIMESTAMP(3) NOT NULL,
+    "pdfUrl" TEXT,
+    "status" "InvoiceStatus" NOT NULL DEFAULT 'DRAFT',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "InvoiceTemplate" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "logoUrl" TEXT,
+    "header" TEXT,
+    "body" TEXT,
+    "footer" TEXT,
+    "emailSubject" TEXT,
+    "emailBody" TEXT,
+    CONSTRAINT "InvoiceTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "InvoiceTemplate_userId_key" ON "InvoiceTemplate"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_contactId_fkey" FOREIGN KEY ("contactId") REFERENCES "Contact"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceTemplate" ADD CONSTRAINT "InvoiceTemplate_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/omnibox/prisma/schema.prisma
+++ b/omnibox/prisma/schema.prisma
@@ -143,3 +143,34 @@ model QuickReply {
   text   String
   user   User   @relation(fields: [userId], references: [id])
 }
+
+enum InvoiceStatus {
+  DRAFT
+  SENT
+  PAID
+}
+
+model Invoice {
+  id        String        @id @default(uuid())
+  userId    String
+  contactId String
+  amount    Float
+  dueDate   DateTime
+  pdfUrl    String?
+  status    InvoiceStatus @default(DRAFT)
+  createdAt DateTime      @default(now())
+  user      User          @relation(fields: [userId], references: [id])
+  contact   Contact       @relation(fields: [contactId], references: [id])
+}
+
+model InvoiceTemplate {
+  id          String @id @default(uuid())
+  userId      String @unique
+  logoUrl     String?
+  header      String?
+  body        String?
+  footer      String?
+  emailSubject String?
+  emailBody    String?
+  user        User   @relation(fields: [userId], references: [id])
+}


### PR DESCRIPTION
## Summary
- add Invoice and InvoiceTemplate models
- add invoicing page with create/view and actions
- provide template editor page
- implement invoice API with SendGrid support
- generate PDFs using pdf-lib
- expose new sidebar link

## Testing
- `pnpm install --no-frozen-lockfile`
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_685e73c70c78832aaf6343c0067be6f8