### PR TITLE
Add invoice editing and template previews

### DIFF
--- a/omnibox/apps/web/app/api/invoice/preview/route.ts
+++ b/omnibox/apps/web/app/api/invoice/preview/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { generateInvoicePdf } from '@/lib/invoice';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const pdfBase64 = await generateInvoicePdf({
+    logoUrl: body.logoUrl,
+    header: body.header,
+    body: body.body,
+    footer: body.footer,
+    amount: body.amount,
+    dueDate: body.dueDate,
+    clientName: body.clientName,
+  });
+  return NextResponse.json({ pdfBase64 });
+}
+

--- a/omnibox/apps/web/app/dashboard/invoices/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/page.tsx
@@ -31,23 +31,50 @@ export default function InvoicesPage() {
     fetcher,
   );
   const [showModal, setShowModal] = useState(false);
-  const [form, setForm] = useState({ contactId: "", amount: "", dueDate: "" });
+  const [editId, setEditId] = useState<string | null>(null);
+  const [form, setForm] = useState({
+    contactId: "",
+    amount: "",
+    dueDate: "",
+    pdfBase64: "",
+  });
+
+  function openNew() {
+    setForm({ contactId: "", amount: "", dueDate: "", pdfBase64: "" });
+    setEditId(null);
+    setShowModal(true);
+  }
+
+  function openEdit(inv: Invoice) {
+    setForm({
+      contactId: inv.contactId,
+      amount: inv.amount.toString(),
+      dueDate: inv.dueDate.split("T")[0],
+      pdfBase64: inv.pdfUrl || "",
+    });
+    setEditId(inv.id);
+    setShowModal(true);
+  }
 
   async function saveInvoice(e: React.FormEvent) {
     e.preventDefault();
-    const res = await fetch("/api/invoices", {
-      method: "POST",
+    const payload = {
+      contactId: form.contactId,
+      amount: parseFloat(form.amount),
+      dueDate: form.dueDate,
+      pdfBase64: form.pdfBase64 || undefined,
+    };
+    const url = editId ? `/api/invoice/${editId}` : "/api/invoices";
+    const method = editId ? "PATCH" : "POST";
+    const res = await fetch(url, {
+      method,
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        contactId: form.contactId,
-        amount: parseFloat(form.amount),
-        dueDate: form.dueDate,
-      }),
+      body: JSON.stringify(payload),
     });
     if (!res.ok) {
-      toast.error("Failed to create invoice");
+      toast.error(editId ? "Failed to update invoice" : "Failed to create invoice");
     } else {
-      toast.success("Invoice created");
+      toast.success(editId ? "Invoice updated" : "Invoice created");
       mutate();
       setShowModal(false);
     }
@@ -69,7 +96,7 @@ export default function InvoicesPage() {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <Button onClick={() => setShowModal(true)}>New Invoice</Button>
+        <Button onClick={openNew}>New Invoice</Button>
       </div>
       {data && 'error' in data && (
         <p className="text-center text-red-500">{(data as any).error}</p>
@@ -89,6 +116,7 @@ export default function InvoicesPage() {
                 <div className="text-sm">Status: {inv.status}</div>
               </div>
               <div className="flex items-center gap-2">
+                <Button onClick={() => openEdit(inv)}>Edit</Button>
                 {inv.status !== "PAID" && (
                   <Button onClick={() => action(inv.id, "markPaid")}>Mark Paid</Button>
                 )}
@@ -110,14 +138,17 @@ export default function InvoicesPage() {
           role="dialog"
           aria-modal="true"
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => setShowModal(false)}
+          onClick={() => {
+            setShowModal(false);
+            setEditId(null);
+          }}
         >
           <form
             onSubmit={saveInvoice}
             className="w-80 space-y-2 rounded bg-white p-4 shadow"
             onClick={(e) => e.stopPropagation()}
           >
-            <h2 className="font-semibold">New Invoice</h2>
+            <h2 className="font-semibold">{editId ? "Edit Invoice" : "New Invoice"}</h2>
             <select
               className="w-full rounded border p-1"
               value={form.contactId}
@@ -141,8 +172,36 @@ export default function InvoicesPage() {
               value={form.dueDate}
               onChange={(e) => setForm({ ...form, dueDate: e.target.value })}
             />
+            <Input
+              type="file"
+              accept="application/pdf"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (!file) return;
+                const reader = new FileReader();
+                reader.onload = (ev) =>
+                  setForm((f) => ({ ...f, pdfBase64: ev.target?.result as string }));
+                reader.readAsDataURL(file);
+              }}
+            />
+            {form.pdfBase64 && (
+              <a
+                href={form.pdfBase64}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-blue-600 underline"
+              >
+                View PDF
+              </a>
+            )}
             <div className="flex justify-end gap-2">
-              <Button type="button" onClick={() => setShowModal(false)}>
+              <Button
+                type="button"
+                onClick={() => {
+                  setShowModal(false);
+                  setEditId(null);
+                }}
+              >
                 Cancel
               </Button>
               <Button type="submit">Save</Button>


### PR DESCRIPTION
## Summary
- allow editing invoices with optional PDF upload
- support optional PDF attachment when creating invoices
- add invoice preview API
- expand invoice template editor with file upload and previews

## Testing
- `pnpm lint` *(fails: error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm check-types` *(fails: error when performing the request to https://registry.npmjs.org/pnpm/latest)*

------
https://chatgpt.com/codex/tasks/task_e_685e84b184ac832aa78d098175e1d133