### PR TITLE
Add invoice search and template editor refinements

### DIFF
--- a/omnibox/apps/web/app/dashboard/invoices/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import useSWR from "swr";
 import { useState } from "react";
+import Link from "next/link";
 import { Input, Button, Card } from "@/components/ui";
 import { toast } from "sonner";
 
@@ -32,6 +33,7 @@ export default function InvoicesPage() {
   );
   const [showModal, setShowModal] = useState(false);
   const [editId, setEditId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
   const [form, setForm] = useState({
     contactId: "",
     amount: "",
@@ -93,20 +95,44 @@ export default function InvoicesPage() {
     }
   }
 
+  const filteredInvoices = data?.invoices.filter((inv) => {
+    if (!search) return true;
+    const q = search.toLowerCase();
+    const statusMatch = inv.status.toLowerCase().includes(q);
+    const actionMatch =
+      (q.includes("mark paid") && inv.status !== "PAID") ||
+      (q.includes("send") && inv.status === "DRAFT");
+    return statusMatch || actionMatch;
+  });
+
   return (
     <div className="space-y-4">
-      <div className="flex justify-end">
-        <Button onClick={openNew}>New Invoice</Button>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex-1 flex justify-center">
+          <Input
+            aria-label="Search invoices"
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full max-w-xs"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Link href="/dashboard/invoices/template" className="underline">
+            Edit Template
+          </Link>
+          <Button onClick={openNew}>New Invoice</Button>
+        </div>
       </div>
       {data && 'error' in data && (
         <p className="text-center text-red-500">{(data as any).error}</p>
       )}
-      {data && Array.isArray(data.invoices) && data.invoices.length === 0 && (
+      {data && Array.isArray(data.invoices) && filteredInvoices?.length === 0 && (
         <p className="text-center text-gray-500">No invoices.</p>
       )}
       {data && Array.isArray(data.invoices) && data.invoices.length > 0 && (
         <div className="space-y-2">
-          {data.invoices.map((inv) => (
+          {filteredInvoices?.map((inv) => (
             <Card key={inv.id} className="flex justify-between p-2">
               <div>
                 <div className="font-semibold">{inv.contact.name || "Unnamed"}</div>

--- a/omnibox/apps/web/app/dashboard/invoices/template/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/template/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import useSWR from "swr";
 import { useState, useEffect } from "react";
-import { Input, Button } from "@/components/ui";
+import { Input, Button, Textarea } from "@/components/ui";
 import { toast } from "sonner";
 
 const fetcher = async (url: string) => {
@@ -74,10 +74,15 @@ export default function InvoiceTemplatePage() {
   return (
     <div className="space-y-2">
       {form.logoUrl && (
-        <img src={form.logoUrl} alt="logo" className="h-16 w-16 object-contain" />
+        <img
+          src={form.logoUrl}
+          alt="Company logo"
+          className="h-16 w-16 object-contain"
+        />
       )}
       <Input
         type="file"
+        aria-label="Company logo"
         accept="image/*"
         onChange={(e) => {
           const file = e.target.files?.[0];
@@ -108,8 +113,7 @@ export default function InvoiceTemplatePage() {
         value={form.emailSubject}
         onChange={(e) => setForm({ ...form, emailSubject: e.target.value })}
       />
-      <textarea
-        className="w-full rounded border p-1"
+      <Textarea
         placeholder="Email Body"
         value={form.emailBody}
         onChange={(e) => setForm({ ...form, emailBody: e.target.value })}


### PR DESCRIPTION
## Summary
- filter invoices by status or action with a search bar
- link to invoice template editor
- clean up template editor UI and accessibility

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e875e7dd8832a94225955bdedbae5