### PR TITLE
Add dedicated invoice creation page

### DIFF
--- a/omnibox/apps/web/app/api/invoices/route.ts
+++ b/omnibox/apps/web/app/api/invoices/route.ts
@@ -18,54 +18,59 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const session = await serverSession();
-  let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
-  const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  try {
+    const session = await serverSession();
+    let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
+    const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
+    if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const body = await req.json();
-  const { contactId, amount, dueDate, pdfBase64, invoiceNumber } = body as {
-    contactId: string;
-    amount: number;
-    dueDate: string;
-    pdfBase64?: string;
-    invoiceNumber?: string;
-  };
-  const contact = await prisma.contact.findFirst({
-    where: { id: contactId, userId: user.id },
-    select: { name: true },
-  });
-  if (!contact) return NextResponse.json({ error: 'Contact not found' }, { status: 404 });
-
-  let pdf = pdfBase64;
-  if (!pdf) {
-    const template = await prisma.invoiceTemplate.findFirst({ where: { userId: user.id } });
-    pdf = await generateInvoicePdf({
-      logoUrl: template?.logoUrl || undefined,
-      header: template?.header || undefined,
-      body: template?.body || undefined,
-      footer: template?.footer || undefined,
-      companyName: template?.companyName || undefined,
-      companyAddress: template?.companyAddress || undefined,
-      notes: template?.notes || undefined,
-      terms: template?.terms || undefined,
-      accentColor: template?.accentColor || undefined,
-      amount,
-      dueDate,
-      clientName: contact.name || 'Client',
+    const body = await req.json();
+    const { contactId, amount, dueDate, pdfBase64, invoiceNumber } = body as {
+      contactId: string;
+      amount: number;
+      dueDate: string;
+      pdfBase64?: string;
+      invoiceNumber?: string;
+    };
+    const contact = await prisma.contact.findFirst({
+      where: { id: contactId, userId: user.id },
+      select: { name: true },
     });
+    if (!contact) return NextResponse.json({ error: 'Contact not found' }, { status: 404 });
+
+    let pdf = pdfBase64;
+    if (!pdf) {
+      const template = await prisma.invoiceTemplate.findFirst({ where: { userId: user.id } });
+      pdf = await generateInvoicePdf({
+        logoUrl: template?.logoUrl || undefined,
+        header: template?.header || undefined,
+        body: template?.body || undefined,
+        footer: template?.footer || undefined,
+        companyName: template?.companyName || undefined,
+        companyAddress: template?.companyAddress || undefined,
+        notes: template?.notes || undefined,
+        terms: template?.terms || undefined,
+        accentColor: template?.accentColor || undefined,
+        amount,
+        dueDate,
+        clientName: contact.name || 'Client',
+      });
+    }
+
+    const invoice = await prisma.invoice.create({
+      data: {
+        userId: user.id,
+        contactId,
+        invoiceNumber: invoiceNumber || undefined,
+        amount,
+        dueDate: new Date(dueDate),
+        pdfUrl: pdf ? (pdf.startsWith('data:') ? pdf : `data:application/pdf;base64,${pdf}`) : undefined,
+      },
+    });
+
+    return NextResponse.json({ invoice }, { status: 201 });
+  } catch (error) {
+    console.error('POST /api/invoices error:', error);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
   }
-
-  const invoice = await prisma.invoice.create({
-    data: {
-      userId: user.id,
-      contactId,
-      invoiceNumber: invoiceNumber || undefined,
-      amount,
-      dueDate: new Date(dueDate),
-      pdfUrl: pdf ? (pdf.startsWith('data:') ? pdf : `data:application/pdf;base64,${pdf}`) : undefined,
-    },
-  });
-
-  return NextResponse.json({ invoice }, { status: 201 });
 }

--- a/omnibox/apps/web/app/dashboard/invoices/new/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/new/page.tsx
@@ -1,0 +1,374 @@
+"use client";
+import useSWR from "swr";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Input, Button, Textarea } from "@/components/ui";
+import { toast } from "sonner";
+import { v4 as uuid } from "uuid";
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+};
+
+interface LineItem {
+  id: string;
+  service: string;
+  description: string;
+  quantity: string;
+  rate: string;
+}
+interface Section {
+  id: string;
+  heading: string;
+  tax: string;
+  items: LineItem[];
+}
+
+export default function NewInvoicePage() {
+  const router = useRouter();
+  const { data: clients } = useSWR<{ clients: { id: string; name: string }[] }>(
+    "/api/clients",
+    fetcher,
+  );
+
+  const [form, setForm] = useState({
+    title: "Invoice",
+    invoiceNumber: "",
+    issueDate: "",
+    dueDate: "",
+    clientName: "",
+    clientId: "",
+    notes: "",
+  });
+  const [sections, setSections] = useState<Section[]>([]);
+
+  useEffect(() => {
+    setForm((f) => ({
+      ...f,
+      invoiceNumber: `INV-${Date.now()}`,
+      issueDate: new Date().toISOString().split("T")[0],
+    }));
+    setSections([
+      {
+        id: uuid(),
+        heading: "Items",
+        tax: "0",
+        items: [
+          { id: uuid(), service: "", description: "", quantity: "1", rate: "" },
+        ],
+      },
+    ]);
+  }, []);
+
+  const idMap = clients?.clients.reduce(
+    (acc, c) => {
+      acc[c.name] = c.id;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  const subtotal = sections.reduce((sum, sec) => {
+    const sectionTotal = sec.items.reduce(
+      (s, it) =>
+        s + (parseFloat(it.rate) || 0) * (parseFloat(it.quantity) || 0),
+      0,
+    );
+    return sum + sectionTotal;
+  }, 0);
+  const taxTotal = sections.reduce((sum, sec) => {
+    const sectionTotal = sec.items.reduce(
+      (s, it) =>
+        s + (parseFloat(it.rate) || 0) * (parseFloat(it.quantity) || 0),
+      0,
+    );
+    return sum + (sectionTotal * (parseFloat(sec.tax) || 0)) / 100;
+  }, 0);
+  const total = subtotal + taxTotal;
+
+  function updateSection(
+    id: string,
+    field: keyof Section,
+    value: string | LineItem[],
+  ) {
+    setSections((secs) =>
+      secs.map((s) => (s.id === id ? { ...s, [field]: value } : s)),
+    );
+  }
+
+  function addSection() {
+    setSections((secs) => [
+      ...secs,
+      {
+        id: uuid(),
+        heading: "",
+        tax: "0",
+        items: [
+          { id: uuid(), service: "", description: "", quantity: "1", rate: "" },
+        ],
+      },
+    ]);
+  }
+
+  function removeSection(id: string) {
+    setSections((secs) => secs.filter((s) => s.id !== id));
+  }
+
+  function addLine(sectionId: string) {
+    setSections((secs) =>
+      secs.map((s) =>
+        s.id === sectionId
+          ? {
+              ...s,
+              items: [
+                ...s.items,
+                {
+                  id: uuid(),
+                  service: "",
+                  description: "",
+                  quantity: "1",
+                  rate: "",
+                },
+              ],
+            }
+          : s,
+      ),
+    );
+  }
+
+  function updateLine(
+    sectionId: string,
+    lineId: string,
+    field: keyof LineItem,
+    value: string,
+  ) {
+    setSections((secs) =>
+      secs.map((s) =>
+        s.id === sectionId
+          ? {
+              ...s,
+              items: s.items.map((it) =>
+                it.id === lineId ? { ...it, [field]: value } : it,
+              ),
+            }
+          : s,
+      ),
+    );
+  }
+
+  function removeLine(sectionId: string, lineId: string) {
+    setSections((secs) =>
+      secs.map((s) =>
+        s.id === sectionId
+          ? { ...s, items: s.items.filter((it) => it.id !== lineId) }
+          : s,
+      ),
+    );
+  }
+
+  async function saveInvoice(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch("/api/invoices", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contactId: form.clientId,
+        invoiceNumber: form.invoiceNumber || undefined,
+        amount: parseFloat(total.toFixed(2)),
+        dueDate: form.dueDate,
+      }),
+    });
+    if (!res.ok) {
+      toast.error("Failed to create invoice");
+      return;
+    }
+    toast.success("Invoice created");
+    router.push("/dashboard/invoices");
+  }
+
+  return (
+    <form onSubmit={saveInvoice} className="space-y-6 p-4">
+      <div className="space-y-2 rounded border p-3">
+        <h2 className="font-semibold">Header</h2>
+        <Input
+          aria-label="Title"
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+        />
+        <Input
+          aria-label="Invoice Number"
+          value={form.invoiceNumber}
+          onChange={(e) => setForm({ ...form, invoiceNumber: e.target.value })}
+        />
+        <div className="flex flex-wrap gap-2">
+          <Input
+            type="date"
+            aria-label="Issue Date"
+            value={form.issueDate}
+            onChange={(e) => setForm({ ...form, issueDate: e.target.value })}
+          />
+          <Input
+            type="date"
+            aria-label="Due Date"
+            value={form.dueDate}
+            onChange={(e) => setForm({ ...form, dueDate: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2 rounded border p-3">
+        <h2 className="font-semibold">Client</h2>
+        <Input
+          list="client-list"
+          placeholder="Search client"
+          value={form.clientName}
+          onChange={(e) => {
+            const name = e.target.value;
+            setForm((f) => ({
+              ...f,
+              clientName: name,
+              clientId: idMap?.[name] || "",
+            }));
+          }}
+        />
+        <datalist id="client-list">
+          {clients?.clients.map((c) => <option key={c.id} value={c.name} />)}
+        </datalist>
+      </div>
+
+      {sections.map((sec) => (
+        <div key={sec.id} className="space-y-2 rounded border p-3">
+          <div className="flex items-center justify-between gap-2">
+            <Input
+              aria-label="Section Heading"
+              value={sec.heading}
+              onChange={(e) => updateSection(sec.id, "heading", e.target.value)}
+              className="flex-1"
+            />
+            <Button type="button" onClick={() => removeSection(sec.id)}>
+              Remove Section
+            </Button>
+          </div>
+          {sec.items.map((li) => (
+            <div key={li.id} className="flex flex-wrap items-end gap-2">
+              <Input
+                placeholder="Service"
+                value={li.service}
+                onChange={(e) =>
+                  updateLine(sec.id, li.id, "service", e.target.value)
+                }
+                className="flex-1"
+              />
+              <Input
+                placeholder="Description"
+                value={li.description}
+                onChange={(e) =>
+                  updateLine(sec.id, li.id, "description", e.target.value)
+                }
+                className="flex-1"
+              />
+              <Input
+                type="number"
+                placeholder="Qty"
+                value={li.quantity}
+                onChange={(e) =>
+                  updateLine(sec.id, li.id, "quantity", e.target.value)
+                }
+                className="w-16"
+              />
+              <Input
+                type="number"
+                placeholder="Rate"
+                value={li.rate}
+                onChange={(e) =>
+                  updateLine(sec.id, li.id, "rate", e.target.value)
+                }
+                className="w-20"
+              />
+              <Input
+                disabled
+                aria-label="Total"
+                value={(
+                  (parseFloat(li.rate) || 0) * (parseFloat(li.quantity) || 0)
+                ).toFixed(2)}
+                className="w-20 bg-gray-100"
+              />
+              <Button
+                type="button"
+                onClick={() => removeLine(sec.id, li.id)}
+                className="self-start"
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          <Button
+            type="button"
+            onClick={() => addLine(sec.id)}
+            className="mt-1"
+          >
+            + Add Line
+          </Button>
+          <div className="flex items-center gap-2 pt-2">
+            <label className="text-sm" htmlFor={`tax-${sec.id}`}>
+              Tax %
+            </label>
+            <Input
+              id={`tax-${sec.id}`}
+              type="number"
+              value={sec.tax}
+              onChange={(e) => updateSection(sec.id, "tax", e.target.value)}
+              className="w-20"
+            />
+          </div>
+        </div>
+      ))}
+
+      <Button type="button" onClick={addSection} className="mt-2">
+        + Add Section
+      </Button>
+
+      <div className="space-y-2 rounded border p-3">
+        <h2 className="font-semibold">Totals & Notes</h2>
+        <div className="flex flex-wrap gap-2">
+          <Input
+            aria-label="Subtotal"
+            value={subtotal.toFixed(2)}
+            disabled
+            className="w-24 bg-gray-100"
+          />
+          <Input
+            aria-label="Tax"
+            value={taxTotal.toFixed(2)}
+            disabled
+            className="w-24 bg-gray-100"
+          />
+          <Input
+            aria-label="Total"
+            value={total.toFixed(2)}
+            disabled
+            className="w-24 bg-gray-100"
+          />
+        </div>
+        <Textarea
+          placeholder="Notes"
+          value={form.notes}
+          onChange={(e) => setForm({ ...form, notes: e.target.value })}
+        />
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" onClick={() => router.back()}>
+          Cancel
+        </Button>
+        <Button type="submit">Save Invoice</Button>
+      </div>
+    </form>
+  );
+}

--- a/omnibox/apps/web/app/dashboard/invoices/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/page.tsx
@@ -28,7 +28,10 @@ const fetcher = async (url: string) => {
 };
 
 export default function InvoicesPage() {
-  const { data, mutate } = useSWR<{ invoices: Invoice[] }>("/api/invoices", fetcher);
+  const { data, mutate } = useSWR<{ invoices: Invoice[] }>(
+    "/api/invoices",
+    fetcher,
+  );
   const { data: clients } = useSWR<{ clients: { id: string; name: string }[] }>(
     "/api/clients",
     fetcher,
@@ -54,19 +57,7 @@ export default function InvoicesPage() {
   const [lineItems, setLineItems] = useState<LineItem[]>([]);
   const [autoAmount, setAutoAmount] = useState(true);
 
-  function openNew() {
-    setForm({
-      contactId: "",
-      invoiceNumber: "",
-      amount: "",
-      dueDate: "",
-      pdfBase64: "",
-    });
-    setLineItems([{ id: uuid(), service: "", description: "", rate: "", quantity: "" }]);
-    setAutoAmount(true);
-    setEditId(null);
-    setShowModal(true);
-  }
+  // New invoices are created on a dedicated page
 
   function openEdit(inv: Invoice) {
     setForm({
@@ -101,9 +92,7 @@ export default function InvoicesPage() {
 
   function updateLine(id: string, field: keyof LineItem, value: string) {
     setLineItems((items) =>
-      items.map((it) =>
-        it.id === id ? { ...it, [field]: value } : it,
-      ),
+      items.map((it) => (it.id === id ? { ...it, [field]: value } : it)),
     );
   }
 
@@ -128,7 +117,9 @@ export default function InvoicesPage() {
       body: JSON.stringify(payload),
     });
     if (!res.ok) {
-      toast.error(editId ? "Failed to update invoice" : "Failed to create invoice");
+      toast.error(
+        editId ? "Failed to update invoice" : "Failed to create invoice",
+      );
     } else {
       toast.success(editId ? "Invoice updated" : "Invoice created");
       mutate();
@@ -198,23 +189,31 @@ export default function InvoicesPage() {
           <Link href="/dashboard/invoices/email-template" className="underline">
             Email Template
           </Link>
-          <Button onClick={openNew}>New Invoice</Button>
+          <Link href="/dashboard/invoices/new" className="underline">
+            New Invoice
+          </Link>
         </div>
       </div>
-      {data && 'error' in data && (
+      {data && "error" in data && (
         <p className="text-center text-red-500">{(data as any).error}</p>
       )}
-      {data && Array.isArray(data.invoices) && filteredInvoices?.length === 0 && (
-        <p className="text-center text-gray-500">No invoices.</p>
-      )}
+      {data &&
+        Array.isArray(data.invoices) &&
+        filteredInvoices?.length === 0 && (
+          <p className="text-center text-gray-500">No invoices.</p>
+        )}
       {data && Array.isArray(data.invoices) && data.invoices.length > 0 && (
         <div className="space-y-2">
           {filteredInvoices?.map((inv) => (
             <Card key={inv.id} className="flex justify-between p-2">
               <div>
-                <div className="font-semibold">{inv.contact.name || "Unnamed"}</div>
+                <div className="font-semibold">
+                  {inv.contact.name || "Unnamed"}
+                </div>
                 {inv.invoiceNumber && (
-                  <div className="text-sm text-gray-500">#{inv.invoiceNumber}</div>
+                  <div className="text-sm text-gray-500">
+                    #{inv.invoiceNumber}
+                  </div>
                 )}
                 <div className="text-sm text-gray-600">
                   ${inv.amount} due {new Date(inv.dueDate).toLocaleDateString()}
@@ -224,13 +223,20 @@ export default function InvoicesPage() {
               <div className="flex items-center gap-2">
                 <Button onClick={() => openEdit(inv)}>Edit</Button>
                 {inv.status !== "PAID" && (
-                  <Button onClick={() => action(inv.id, "markPaid")}>Mark Paid</Button>
+                  <Button onClick={() => action(inv.id, "markPaid")}>
+                    Mark Paid
+                  </Button>
                 )}
                 {inv.status === "DRAFT" && (
                   <Button onClick={() => action(inv.id, "send")}>Send</Button>
                 )}
                 {inv.pdfUrl && (
-                  <a href={inv.pdfUrl} target="_blank" rel="noreferrer" className="text-blue-600 underline">
+                  <a
+                    href={inv.pdfUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-blue-600 underline"
+                  >
                     PDF
                   </a>
                 )}
@@ -254,7 +260,9 @@ export default function InvoicesPage() {
             className="w-80 space-y-2 rounded bg-white p-4 shadow"
             onClick={(e) => e.stopPropagation()}
           >
-            <h2 className="font-semibold">{editId ? "Edit Invoice" : "New Invoice"}</h2>
+            <h2 className="font-semibold">
+              {editId ? "Edit Invoice" : "New Invoice"}
+            </h2>
             <select
               className="w-full rounded border p-1"
               value={form.contactId}
@@ -275,16 +283,11 @@ export default function InvoicesPage() {
               }
             />
             {lineItems.map((li) => (
-              <div
-                key={li.id}
-                className="flex flex-wrap items-end gap-2"
-              >
+              <div key={li.id} className="flex flex-wrap items-end gap-2">
                 <Input
                   placeholder="Service"
                   value={li.service}
-                  onChange={(e) =>
-                    updateLine(li.id, "service", e.target.value)
-                  }
+                  onChange={(e) => updateLine(li.id, "service", e.target.value)}
                   className="flex-1"
                 />
                 <Input
@@ -315,8 +318,7 @@ export default function InvoicesPage() {
                   disabled
                   aria-label="Total"
                   value={(
-                    (parseFloat(li.rate) || 0) *
-                    (parseFloat(li.quantity) || 0)
+                    (parseFloat(li.rate) || 0) * (parseFloat(li.quantity) || 0)
                   ).toFixed(2)}
                   className="w-20 bg-gray-100"
                 />
@@ -352,7 +354,10 @@ export default function InvoicesPage() {
                 if (!file) return;
                 const reader = new FileReader();
                 reader.onload = (ev) =>
-                  setForm((f) => ({ ...f, pdfBase64: ev.target?.result as string }));
+                  setForm((f) => ({
+                    ...f,
+                    pdfBase64: ev.target?.result as string,
+                  }));
                 reader.readAsDataURL(file);
               }}
             />


### PR DESCRIPTION
## Summary
- add try/catch to `/api/invoices` to avoid 500s and log errors
- create `/dashboard/invoices/new` single-pane form for building invoices
- link to the new form from the invoices dashboard

## Testing
- `pnpm lint` *(fails: `@repo/ui:lint` command exited with code 1)*
- `pnpm build` *(fails: `turbo` run failed)*

------
https://chatgpt.com/codex/tasks/task_e_685eaacbb920832abfd24c3581edae83