### PR TITLE
Implement fixed-layout invoice editor

### DIFF
--- a/omnibox/apps/web/app/api/invoice/preview/route.ts
+++ b/omnibox/apps/web/app/api/invoice/preview/route.ts
@@ -3,21 +3,7 @@ import { generateInvoicePdf } from '@/lib/invoice';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
-  const pdfBase64 = await generateInvoicePdf({
-    logoUrl: body.logoUrl,
-    header: body.header,
-    body: body.body,
-    footer: body.footer,
-    companyName: body.companyName,
-    companyAddress: body.companyAddress,
-    notes: body.notes,
-    terms: body.terms,
-    accentColor: body.accentColor,
-    layout: body.layout,
-    amount: body.amount,
-    dueDate: body.dueDate,
-    clientName: body.clientName,
-  });
+  const pdfBase64 = await generateInvoicePdf(body as any);
   return NextResponse.json({ pdfBase64 });
 }
 


### PR DESCRIPTION
## Summary
- rewrite invoice template editor to use rigid sections
- support line items with column visibility and live preview
- update PDF generator for fixed table structure
- simplify preview API to passthrough request body

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm --filter web run check-types` *(fails: cannot find type definition)*

------
https://chatgpt.com/codex/tasks/task_e_686295940a60832ab1778b4518623e6e