### PR TITLE
Fix invoice edit client details and PDF view

### DIFF
--- a/omnibox/apps/web/app/dashboard/invoices/new/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/new/page.tsx
@@ -129,13 +129,18 @@ export default function NewInvoicePage() {
   useEffect(() => {
     if (existing?.invoice) {
       const inv = existing.invoice;
-      const name =
-        clients?.clients.find((c) => c.id === inv.contactId)?.name ||
-        inv.contact?.name;
+      const client = clients?.clients.find((c) => c.id === inv.contactId);
+      const name = client?.name || inv.contact?.name;
+      const buyerInfo = client
+        ? [client.name, client.company, client.email, client.phone]
+            .filter(Boolean)
+            .join("\n")
+        : undefined;
       setForm((f) => ({
         ...f,
         clientId: inv.contactId,
         clientName: name || f.clientName,
+        buyerAddress: buyerInfo ?? f.buyerAddress,
         invoiceNumber: inv.invoiceNumber || f.invoiceNumber,
         dueDate: inv.dueDate.split("T")[0],
       }));

--- a/omnibox/apps/web/app/dashboard/invoices/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/page.tsx
@@ -94,9 +94,16 @@ export default function InvoicesPage() {
   }
 
   function openPdf(url: string) {
-    // The stored PDF is a data URL, so opening it directly is simpler and
-    // avoids issues with manual base64 decoding.
-    window.open(url, "_blank");
+    // Decode the base64 data and open using a Blob to improve compatibility
+    const base64 = url.includes(',') ? url.split(',')[1] : url;
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    const blobUrl = URL.createObjectURL(
+      new Blob([bytes], { type: "application/pdf" }),
+    );
+    window.open(blobUrl, "_blank");
+    setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
   }
 
   const filteredInvoices = data?.invoices.filter((inv) => {


### PR DESCRIPTION
## Summary
- preserve client data when editing invoices by pre-filling buyer info
- open invoice PDFs using blobs for better browser support

## Testing
- `pnpm lint` *(fails: command exited with error)*
- `pnpm build` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_68654bcca168832ab1ab4b590ad4751c