### PR TITLE
Improve invoice PDF layout

### DIFF
--- a/omnibox/apps/web/lib/invoice.ts
+++ b/omnibox/apps/web/lib/invoice.ts
@@ -2,6 +2,7 @@ import { PDFDocument, StandardFonts } from 'pdf-lib';
 
 export interface LineItem {
   item: string;
+  description?: string;
   quantity: string;
   rate: string;
   tax: string;
@@ -33,7 +34,25 @@ export async function generateInvoicePdf(data: InvoiceData) {
   const doc = await PDFDocument.create();
   const page = doc.addPage([595, 842]);
   const font = await doc.embedFont(StandardFonts.Helvetica);
+  const pageWidth = page.getWidth();
+  const margin = 50;
+  const tableWidth = pageWidth - margin * 2;
   let y = 780;
+
+  const drawLines = (
+    text: string,
+    x: number,
+    startY: number,
+    lineHeight: number = 12,
+    size: number = 10,
+  ) => {
+    let yy = startY;
+    for (const line of text.split(/\r?\n/)) {
+      page.drawText(line, { x, y: yy, size, font });
+      yy -= lineHeight;
+    }
+    return yy;
+  };
 
   if (data.logoUrl) {
     try {
@@ -51,7 +70,7 @@ export async function generateInvoicePdf(data: InvoiceData) {
       const img = mime.includes('png')
         ? await doc.embedPng(bytes)
         : await doc.embedJpg(bytes);
-      page.drawImage(img, { x: 50, y: y - 40, width: 100, height: 40 });
+      page.drawImage(img, { x: margin, y: y - 40, width: 100, height: 40 });
     } catch {
       // ignore image errors
     }
@@ -59,49 +78,60 @@ export async function generateInvoicePdf(data: InvoiceData) {
   y -= 60;
 
   if (data.companyAddress) {
-    page.drawText(data.companyAddress, { x: 50, y, size: 10, font });
+    y = drawLines(data.companyAddress, margin, y, 12, 10) - 5;
   }
-  y -= 20;
 
   if (data.clientAddress) {
-    page.drawText('Bill To:', { x: 50, y, size: 12, font });
-    page.drawText(data.clientAddress, { x: 110, y, size: 10, font });
+    page.drawText('Bill To:', { x: margin, y, size: 12, font });
+    y = drawLines(data.clientAddress, margin + 60, y, 12, 10) - 5;
   }
-  y -= 20;
 
   if (data.invoiceNumber) {
-    page.drawText(`Invoice #: ${data.invoiceNumber}`, { x: 50, y, size: 10, font });
+    page.drawText(`Invoice #: ${data.invoiceNumber}`, { x: margin, y, size: 10, font });
   }
   if (data.invoiceDate) {
-    page.drawText(`Invoice Date: ${data.invoiceDate}`, { x: 200, y, size: 10, font });
+    page.drawText(`Invoice Date: ${data.invoiceDate}`, { x: margin + 150, y, size: 10, font });
   }
   if (data.dueDate) {
-    page.drawText(`Due Date: ${data.dueDate}`, { x: 380, y, size: 10, font });
+    page.drawText(`Due Date: ${data.dueDate}`, { x: margin + 300, y, size: 10, font });
   }
   y -= 30;
 
   const showTax = data.columns?.tax !== false;
   const headerY = y;
-  page.drawText('Item', { x: 50, y: headerY, size: 10, font });
-  page.drawText('Qty', { x: 250, y: headerY, size: 10, font });
-  page.drawText('Rate', { x: 290, y: headerY, size: 10, font });
-  if (showTax) page.drawText('Tax', { x: 340, y: headerY, size: 10, font });
-  const subX = showTax ? 390 : 340;
-  page.drawText('Subtotal', { x: subX, y: headerY, size: 10, font });
+  const itemW = tableWidth * 0.2;
+  const descW = tableWidth * 0.4;
+  const smallW = tableWidth * (40 / (showTax ? 4 : 3)) / 100;
+  const xItem = margin;
+  const xDesc = xItem + itemW;
+  const xQty = xDesc + descW;
+  const xRate = xQty + smallW;
+  const xTax = showTax ? xRate + smallW : xRate;
+  const xSub = showTax ? xTax + smallW : xRate + smallW;
+
+  page.drawText('Item', { x: xItem, y: headerY, size: 10, font });
+  page.drawText('Description', { x: xDesc, y: headerY, size: 10, font });
+  page.drawText('Qty', { x: xQty, y: headerY, size: 10, font });
+  page.drawText('Rate', { x: xRate, y: headerY, size: 10, font });
+  if (showTax) page.drawText('Tax %', { x: xTax, y: headerY, size: 10, font });
+  page.drawText('Subtotal', { x: xSub, y: headerY, size: 10, font });
   y -= 15;
 
   const items = data.items || [];
   for (const it of items) {
     const qty = parseFloat(it.quantity) || 0;
     const rate = parseFloat(it.rate) || 0;
-    const tax = parseFloat(it.tax) || 0;
     const sub = qty * rate;
-    page.drawText(it.item, { x: 50, y, size: 10, font });
-    page.drawText(it.quantity, { x: 250, y, size: 10, font });
-    page.drawText(it.rate, { x: 290, y, size: 10, font });
-    if (showTax) page.drawText(it.tax, { x: 340, y, size: 10, font });
-    page.drawText(sub.toFixed(2), { x: subX, y, size: 10, font });
-    y -= 15;
+    const startY = y;
+    page.drawText(it.item, { x: xItem, y: startY, size: 10, font });
+    const descEndY = it.description
+      ? drawLines(it.description, xDesc, startY, 12, 10)
+      : startY;
+    page.drawText(it.quantity, { x: xQty, y: startY, size: 10, font });
+    page.drawText(it.rate, { x: xRate, y: startY, size: 10, font });
+    if (showTax) page.drawText(it.tax, { x: xTax, y: startY, size: 10, font });
+    page.drawText(sub.toFixed(2), { x: xSub, y: startY, size: 10, font });
+    y = descEndY - 15;
   }
 
   const subtotal = items.reduce(
@@ -117,25 +147,23 @@ export async function generateInvoicePdf(data: InvoiceData) {
   const total = subtotal + taxTotal;
 
   y -= 10;
-  page.drawText(`Subtotal: $${subtotal.toFixed(2)}`, { x: subX, y, size: 10, font });
+  page.drawText(`Subtotal: $${subtotal.toFixed(2)}`, { x: xSub, y, size: 10, font });
   y -= 12;
   if (showTax) {
-    page.drawText(`Tax: $${taxTotal.toFixed(2)}`, { x: subX, y, size: 10, font });
+    page.drawText(`Tax: $${taxTotal.toFixed(2)}`, { x: xSub, y, size: 10, font });
     y -= 12;
   }
-  page.drawText(`Total: $${total.toFixed(2)}`, { x: subX, y, size: 12, font });
+  page.drawText(`Total: $${total.toFixed(2)}`, { x: xSub, y, size: 12, font });
   y -= 30;
 
   if (data.notes) {
-    page.drawText(data.notes, { x: 50, y, size: 10, font });
-    y -= 20;
+    y = drawLines(data.notes, margin, y, 12, 10) - 5;
   }
   if (data.terms) {
-    page.drawText(data.terms, { x: 50, y, size: 8, font });
-    y -= 15;
+    y = drawLines(data.terms, margin, y, 10, 8) - 5;
   }
   if (data.footer) {
-    page.drawText(data.footer, { x: 50, y: 40, size: 10, font });
+    drawLines(data.footer, margin, 40, 12, 10);
   }
 
   const bytes = await doc.save();


### PR DESCRIPTION
## Summary
- add description support to invoice line items
- restructure `generateInvoicePdf` for better alignment
- render buyer, totals, notes and footer with proper spacing

## Testing
- `pnpm lint` *(fails: command not found or network issue)*
- `pnpm check-types` *(fails: command not found or network issue)*

------
https://chatgpt.com/codex/tasks/task_e_68662dde750c832ab542c2b6f39d0dca