### PR TITLE
Fix invoice PDF width

### DIFF
--- a/omnibox/apps/web/app/dashboard/invoices/new/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/new/page.tsx
@@ -147,16 +147,22 @@ export default function NewInvoicePage() {
     }
   }, [existing, clients]);
 
-  const idMap = clients?.clients.reduce((acc, c) => {
-    acc[c.name] = c.id;
-    return acc;
-  }, {} as Record<string, string>);
+  const idMap = clients?.clients.reduce(
+    (acc, c) => {
+      acc[c.name] = c.id;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
 
-  const infoMap = clients?.clients.reduce((acc, c) => {
-    const parts = [c.name, c.company, c.email, c.phone].filter(Boolean);
-    acc[c.name] = parts.join("\n");
-    return acc;
-  }, {} as Record<string, string>);
+  const infoMap = clients?.clients.reduce(
+    (acc, c) => {
+      const parts = [c.name, c.company, c.email, c.phone].filter(Boolean);
+      acc[c.name] = parts.join("\n");
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
 
   function updateItem(id: string, field: keyof LineItem, value: string) {
     setForm((f) => ({
@@ -225,7 +231,9 @@ export default function NewInvoicePage() {
       }),
     });
     if (!res.ok) {
-      toast.error(invoiceId ? "Failed to update invoice" : "Failed to create invoice");
+      toast.error(
+        invoiceId ? "Failed to update invoice" : "Failed to create invoice",
+      );
       return;
     }
     toast.success(invoiceId ? "Invoice updated" : "Invoice created");
@@ -234,7 +242,10 @@ export default function NewInvoicePage() {
 
   function Preview() {
     return (
-      <div className="mx-auto w-full max-w-lg space-y-2 rounded border bg-white p-4">
+      <div
+        className="mx-auto w-full space-y-2 rounded border bg-white p-4"
+        style={{ maxWidth: "190mm" }}
+      >
         <div className="flex justify-between">
           <div>
             {form.logoUrl && (
@@ -260,8 +271,8 @@ export default function NewInvoicePage() {
         </div>
         <table className="mt-2 w-full text-sm table-fixed">
           <colgroup>
-            <col style={{ width: '20%' }} />
-            <col style={{ width: '40%' }} />
+            <col style={{ width: "20%" }} />
+            <col style={{ width: "40%" }} />
             <col style={{ width: `${smallColWidth}%` }} />
             <col style={{ width: `${smallColWidth}%` }} />
             {form.showTax && <col style={{ width: `${smallColWidth}%` }} />}
@@ -400,8 +411,8 @@ export default function NewInvoicePage() {
           <div className="font-semibold">Line Items</div>
           <table className="w-full text-sm table-fixed">
             <colgroup>
-              <col style={{ width: '20%' }} />
-              <col style={{ width: '40%' }} />
+              <col style={{ width: "20%" }} />
+              <col style={{ width: "40%" }} />
               <col style={{ width: `${smallColWidth}%` }} />
               <col style={{ width: `${smallColWidth}%` }} />
               {form.showTax && <col style={{ width: `${smallColWidth}%` }} />}

--- a/omnibox/apps/web/app/dashboard/invoices/template/page.tsx
+++ b/omnibox/apps/web/app/dashboard/invoices/template/page.tsx
@@ -50,30 +50,28 @@ export default function InvoiceTemplatePage() {
         logoUrl: t.logoUrl || "",
         sellerAddress: t.companyAddress || "",
         buyerAddress:
-          typeof t.layout?.buyerAddress === "string" ? t.layout.buyerAddress : "",
+          typeof t.layout?.buyerAddress === "string"
+            ? t.layout.buyerAddress
+            : "",
         invoiceNumber:
           typeof t.layout?.invoiceNumber === "string"
             ? t.layout.invoiceNumber
             : "",
         invoiceDate:
           typeof t.layout?.invoiceDate === "string" ? t.layout.invoiceDate : "",
-        dueDate:
-          typeof t.layout?.dueDate === "string" ? t.layout.dueDate : "",
+        dueDate: typeof t.layout?.dueDate === "string" ? t.layout.dueDate : "",
         notes: t.notes || "",
         terms: t.terms || "",
         footer: t.footer || "",
-        items:
-          Array.isArray(t.layout?.items)
-            ? t.layout.items.map((it: any) => ({
-                id: it.id || uuid(),
-                item: it.item || "",
-                quantity: it.quantity || "1",
-                rate: it.rate || "",
-                tax: it.tax || "",
-              }))
-            : [
-                { id: uuid(), item: "", quantity: "1", rate: "", tax: "" },
-              ],
+        items: Array.isArray(t.layout?.items)
+          ? t.layout.items.map((it: any) => ({
+              id: it.id || uuid(),
+              item: it.item || "",
+              quantity: it.quantity || "1",
+              rate: it.rate || "",
+              tax: it.tax || "",
+            }))
+          : [{ id: uuid(), item: "", quantity: "1", rate: "", tax: "" }],
         showTax: t.layout?.columns?.tax !== false,
       });
     } else if (!form.items.length) {
@@ -106,7 +104,8 @@ export default function InvoiceTemplatePage() {
   }
 
   const subtotal = form.items.reduce(
-    (sum, it) => sum + (parseFloat(it.rate) || 0) * (parseFloat(it.quantity) || 0),
+    (sum, it) =>
+      sum + (parseFloat(it.rate) || 0) * (parseFloat(it.quantity) || 0),
     0,
   );
   const taxTotal = form.items.reduce(
@@ -181,11 +180,18 @@ export default function InvoiceTemplatePage() {
 
   function Preview() {
     return (
-      <div className="mx-auto w-full max-w-lg space-y-2 rounded border bg-white p-4">
+      <div
+        className="mx-auto w-full space-y-2 rounded border bg-white p-4"
+        style={{ maxWidth: "190mm" }}
+      >
         <div className="flex justify-between">
           <div>
             {form.logoUrl && (
-              <img src={form.logoUrl} alt="Logo" className="h-16 object-contain" />
+              <img
+                src={form.logoUrl}
+                alt="Logo"
+                className="h-16 object-contain"
+              />
             )}
             <div className="whitespace-pre-wrap text-sm">
               {form.sellerAddress}
@@ -220,7 +226,9 @@ export default function InvoiceTemplatePage() {
                   <td className="py-1">{it.item}</td>
                   <td className="py-1 text-right">{it.quantity}</td>
                   <td className="py-1 text-right">{it.rate}</td>
-                  {form.showTax && <td className="py-1 text-right">{it.tax}</td>}
+                  {form.showTax && (
+                    <td className="py-1 text-right">{it.tax}</td>
+                  )}
                   <td className="py-1 text-right">{sub.toFixed(2)}</td>
                 </tr>
               );
@@ -430,4 +438,3 @@ export default function InvoiceTemplatePage() {
     </div>
   );
 }
-

--- a/omnibox/apps/web/lib/invoice.ts
+++ b/omnibox/apps/web/lib/invoice.ts
@@ -78,9 +78,9 @@ function buildInvoiceHtml(data: InvoiceData) {
     })
     .join("");
   return `<!DOCTYPE html><html><head><meta charset="UTF-8"/><style>
-    @page{size:A4;margin:0.5in;}
+    @page{size:A4;margin:10mm;}
     body{font-family:Arial,Helvetica,sans-serif;margin:0;padding:0;-webkit-print-color-adjust:exact;}
-    .container{width:100%;margin:0 auto;background:#fff;border:1px solid #ccc;border-radius:6px;padding:16px;}
+    .container{box-sizing:border-box;width:100%;max-width:100%;margin:0 auto;background:#fff;border:1px solid #e5e7eb;border-radius:8px;padding:16px;}
     .flex{display:flex;justify-content:space-between;}
     .info{font-size:14px;margin-top:8px;}
     .whitespace-pre-wrap{white-space:pre-wrap;}
@@ -147,12 +147,13 @@ function buildInvoiceHtml(data: InvoiceData) {
 export async function generateInvoicePdf(data: InvoiceData) {
   const browser = await puppeteer.launch({ args: ["--no-sandbox"] });
   const page = await browser.newPage();
-  await page.emulateMediaType("screen");
+  await page.emulateMediaType("print");
   await page.setContent(buildInvoiceHtml(data), { waitUntil: "networkidle0" });
   const pdf = await page.pdf({
     printBackground: true,
-    preferCSSPageSize: true,
-    margin: { top: "0", right: "0", bottom: "0", left: "0" },
+    format: "A4",
+    scale: 1,
+    margin: { top: "10mm", right: "10mm", bottom: "10mm", left: "10mm" },
   });
   await browser.close();
   return Buffer.from(pdf).toString("base64");


### PR DESCRIPTION
## Summary
- adjust invoice template preview width
- match invoice preview width on new invoice page
- generate PDFs in A4 with 10 mm margins and scale 1

## Testing
- `pnpm --dir omnibox lint` *(fails: turbo exited with code 1)*
- `pnpm --dir omnibox build` *(fails: turbo exited with code 1)*
- `pnpm --dir omnibox check-types` *(fails: turbo exited with code 1)*
- `pnpm --dir omnibox format`

------
https://chatgpt.com/codex/tasks/task_e_686645327560832ab7210d47ed9da092