### PR TITLE
Refactor admin route data

### DIFF
--- a/omnibox/apps/web/app/api/admin/features/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/features/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
-import { FLAGS } from "../route";
+import { FLAGS } from "@/lib/admin-data";
 
 export async function POST(
   req: Request,

--- a/omnibox/apps/web/app/api/admin/features/route.ts
+++ b/omnibox/apps/web/app/api/admin/features/route.ts
@@ -1,11 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
-
-let FLAGS: { id: string; name: string; enabled: boolean }[] = [
-  { id: "beta", name: "Beta Features", enabled: false },
-  { id: "new-ui", name: "New UI", enabled: false },
-];
-let TEMPLATES: { id: string; text: string }[] = [];
+import { FLAGS, TEMPLATES } from "@/lib/admin-data";
 
 export async function GET() {
   const session = await serverSession();
@@ -26,4 +21,3 @@ export async function POST(req: NextRequest) {
   return NextResponse.json({ ok: true });
 }
 
-export { FLAGS, TEMPLATES };

--- a/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
-import { LOGS } from "../route";
+import { LOGS } from "@/lib/admin-data";
 
 export async function POST(
   req: NextRequest,

--- a/omnibox/apps/web/app/api/admin/logs/route.ts
+++ b/omnibox/apps/web/app/api/admin/logs/route.ts
@@ -1,12 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
-
-export let LOGS: {
-  id: string;
-  timestamp: string;
-  message: string;
-  resolved: boolean;
-}[] = [];
+import { LOGS } from "@/lib/admin-data";
 
 export async function GET(req: NextRequest) {
   const session = await serverSession();

--- a/omnibox/apps/web/app/api/admin/templates/route.ts
+++ b/omnibox/apps/web/app/api/admin/templates/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
-import { TEMPLATES } from "../features/route";
+import { TEMPLATES } from "@/lib/admin-data";
 
 export async function POST(req: NextRequest) {
   const session = await serverSession();

--- a/omnibox/apps/web/lib/admin-data.ts
+++ b/omnibox/apps/web/lib/admin-data.ts
@@ -1,0 +1,13 @@
+export const FLAGS: { id: string; name: string; enabled: boolean }[] = [
+  { id: "beta", name: "Beta Features", enabled: false },
+  { id: "new-ui", name: "New UI", enabled: false },
+];
+
+export const TEMPLATES: { id: string; text: string }[] = [];
+
+export const LOGS: {
+  id: string;
+  timestamp: string;
+  message: string;
+  resolved: boolean;
+}[] = [];


### PR DESCRIPTION
## Summary
- centralize admin constants in `admin-data.ts`
- load admin routes from shared data module

## Testing
- `pnpm --filter ./apps/web lint`
- `pnpm --filter ./apps/web check-types` *(fails: could not find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6867d07fb17c832abe82dc71b33b6cc3