### PR TITLE
Accept context param in API routes

### DIFF
--- a/omnibox/apps/web/app/api/admin/features/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/features/[id]/route.ts
@@ -4,13 +4,14 @@ import { FLAGS } from "@/lib/admin-data";
 
 export async function POST(
   req: Request,
-  { params },
+  context: { params: { id: string } },
 ) {
+  const { id } = context.params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
-  const flag = FLAGS.find((f) => f.id === params.id);
+  const flag = FLAGS.find((f) => f.id === id);
   if (flag) flag.enabled = !flag.enabled;
   return NextResponse.json({ ok: true });
 }

--- a/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
@@ -4,13 +4,14 @@ import { LOGS } from "@/lib/admin-data";
 
 export async function POST(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  context: { params: { id: string } },
 ) {
+  const { id } = context.params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
-  const log = LOGS.find((l) => l.id === params.id);
+  const log = LOGS.find((l) => l.id === id);
   if (log) log.resolved = !log.resolved;
   return NextResponse.json({ ok: true });
 }

--- a/omnibox/apps/web/app/api/client/[id]/route.ts
+++ b/omnibox/apps/web/app/api/client/[id]/route.ts
@@ -5,8 +5,9 @@ import { Prisma } from "@prisma/client";
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  context: { params: { id: string } },
 ) {
+  const { id } = context.params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({
@@ -35,7 +36,6 @@ export async function PATCH(
     avatar?: string;
   };
 
-  const { id } = await params;
   try {
     const client = await prisma.contact.update({
       where: { id, userId: user.id },
@@ -59,8 +59,9 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  context: { params: { id: string } },
 ) {
+  const { id } = context.params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({
@@ -70,7 +71,6 @@ export async function DELETE(
   if (!user)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { id } = await params;
   await prisma.deal.deleteMany({ where: { contactId: id, userId: user.id } });
   await prisma.contact.delete({ where: { id, userId: user.id } });
 

--- a/omnibox/apps/web/app/api/deal/[id]/route.ts
+++ b/omnibox/apps/web/app/api/deal/[id]/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  req: NextRequest,
+  context: { params: { id: string } },
+) {
+  const { id } = context.params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -11,20 +15,24 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   const { stage } = await req.json();
 
   const deal = await prisma.deal.update({
-    where: { id: params.id, userId: user.id },
+    where: { id, userId: user.id },
     data: { stage },
   });
 
   return NextResponse.json({ deal });
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  _req: NextRequest,
+  context: { params: { id: string } },
+) {
+  const { id } = context.params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  await prisma.deal.delete({ where: { id: params.id, userId: user.id } });
+  await prisma.deal.delete({ where: { id, userId: user.id } });
 
   return NextResponse.json({});
 }

--- a/omnibox/apps/web/app/api/invoice/[id]/route.ts
+++ b/omnibox/apps/web/app/api/invoice/[id]/route.ts
@@ -9,9 +9,9 @@ const EMAIL_FROM = process.env.EMAIL_FROM!;
 
 export async function GET(
   _req: NextRequest,
-  { params }: { params: { id: string } },
+  context: { params: { id: string } },
 ) {
-  const { id } = await params;
+  const { id } = context.params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -26,8 +26,11 @@ export async function GET(
   return NextResponse.json({ invoice });
 }
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  const { id } = await params;
+export async function PATCH(
+  req: NextRequest,
+  context: { params: { id: string } },
+) {
+  const { id } = context.params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -190,8 +193,11 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   return NextResponse.json({ invoice });
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
-  const { id } = await params;
+export async function DELETE(
+  _req: NextRequest,
+  context: { params: { id: string } },
+) {
+  const { id } = context.params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });


### PR DESCRIPTION
## Summary
- refactor dynamic `route.ts` files to receive context
- destructure `id` from `context.params`

## Testing
- `pnpm lint` *(fails: ENETUNREACH while fetching pnpm)*
- `pnpm check-types` *(fails: ENETUNREACH while fetching pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6867d7265928832ab46639ec70ff5720