### PR TITLE
Fix build error due to Next.js type update

### DIFF
--- a/omnibox/apps/web/app/api/admin/features/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/features/[id]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { AppRouteHandlerFnContext } from "next/dist/server/route-modules/app-route/module";
+type RouteContext = { params: { id: string } };
 import { serverSession } from "@/lib/auth";
 import { FLAGS } from "@/lib/admin-data";
 
 export async function POST(
   req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();

--- a/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { AppRouteHandlerFnContext } from "next/dist/server/route-modules/app-route/module";
+type RouteContext = { params: { id: string } };
 import { serverSession } from "@/lib/auth";
 import { LOGS } from "@/lib/admin-data";
 
 export async function POST(
   req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();

--- a/omnibox/apps/web/app/api/client/[id]/route.ts
+++ b/omnibox/apps/web/app/api/client/[id]/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { AppRouteHandlerFnContext } from "next/dist/server/route-modules/app-route/module";
+type RouteContext = { params: { id: string } };
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 import { Prisma } from "@prisma/client";
 
 export async function PATCH(
   req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();
@@ -60,7 +60,7 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();

--- a/omnibox/apps/web/app/api/deal/[id]/route.ts
+++ b/omnibox/apps/web/app/api/deal/[id]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import type { AppRouteHandlerFnContext } from "next/dist/server/route-modules/app-route/module";
+type RouteContext = { params: { id: string } };
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 
 export async function PATCH(
   req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();
@@ -25,7 +25,7 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();

--- a/omnibox/apps/web/app/api/invoice/[id]/route.ts
+++ b/omnibox/apps/web/app/api/invoice/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import type { AppRouteHandlerFnContext } from 'next/dist/server/route-modules/app-route/module';
+type RouteContext = { params: { id: string } };
 import prisma from '@/lib/prisma';
 import { serverSession } from '@/lib/auth';
 import sgMail from '@sendgrid/mail';
@@ -10,7 +10,7 @@ const EMAIL_FROM = process.env.EMAIL_FROM!;
 
 export async function GET(
   _req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();
@@ -29,7 +29,7 @@ export async function GET(
 
 export async function PATCH(
   req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();
@@ -196,7 +196,7 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: AppRouteHandlerFnContext,
+  { params }: RouteContext,
 ) {
   const { id } = (await params) as { id: string };
   const session = await serverSession();


### PR DESCRIPTION
## Summary
- remove imports of `AppRouteHandlerFnContext`
- define local `RouteContext` type for route handlers
- update POST/PATCH/DELETE handlers to use new type

## Testing
- `pnpm install` *(fails: network unreachable)*
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6867dd57d844832a8771e6e3de05bef8