### PR TITLE
Fix context parameter types in API routes

### DIFF
--- a/omnibox/apps/web/app/api/admin/features/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/features/[id]/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-type RouteContext = { params: { id: string } };
 import { serverSession } from "@/lib/auth";
 import { FLAGS } from "@/lib/admin-data";
 
 export async function POST(
   req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });

--- a/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-type RouteContext = { params: { id: string } };
 import { serverSession } from "@/lib/auth";
 import { LOGS } from "@/lib/admin-data";
 
 export async function POST(
   req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });

--- a/omnibox/apps/web/app/api/client/[id]/route.ts
+++ b/omnibox/apps/web/app/api/client/[id]/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-type RouteContext = { params: { id: string } };
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 import { Prisma } from "@prisma/client";
 
 export async function PATCH(
   req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({
@@ -60,9 +59,9 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({

--- a/omnibox/apps/web/app/api/deal/[id]/route.ts
+++ b/omnibox/apps/web/app/api/deal/[id]/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-type RouteContext = { params: { id: string } };
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 
 export async function PATCH(
   req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -25,9 +24,9 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });

--- a/omnibox/apps/web/app/api/invoice/[id]/route.ts
+++ b/omnibox/apps/web/app/api/invoice/[id]/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server';
-type RouteContext = { params: { id: string } };
 import prisma from '@/lib/prisma';
 import { serverSession } from '@/lib/auth';
 import sgMail from '@sendgrid/mail';
@@ -10,9 +9,9 @@ const EMAIL_FROM = process.env.EMAIL_FROM!;
 
 export async function GET(
   _req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -29,9 +28,9 @@ export async function GET(
 
 export async function PATCH(
   req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -196,9 +195,9 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: RouteContext,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });


### PR DESCRIPTION
## Summary
- use inline `{ params }` type in dynamic route handlers

## Testing
- `pnpm install` *(fails: ENETUNREACH)*
- `pnpm lint` *(fails: command exited with code 1)*
- `pnpm build` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6867e071abcc832a8823a0599ec9e764