### PR TITLE
Fix Vercel build by adding sonner type

### DIFF
--- a/omnibox/apps/web/tsconfig.json
+++ b/omnibox/apps/web/tsconfig.json
@@ -7,14 +7,15 @@
     "baseUrl": ".",            
     "paths": { "@/*": ["./*"] },
 
-    "types": ["node"]          
+    "types": ["node", "./types/sonner"]
   },
   "include": [
     "**/*.ts",
     "**/*.tsx",
     "next-env.d.ts",
     "next.config.js",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "types/**/*.d.ts"
   ],
   "exclude": ["node_modules"]
 }

--- a/omnibox/apps/web/types/sonner.d.ts
+++ b/omnibox/apps/web/types/sonner.d.ts
@@ -1,0 +1,3 @@
+declare module "sonner" {
+  export * from "sonner/dist/index";
+}


### PR DESCRIPTION
## Summary
- add local TypeScript declaration for the `sonner` package
- include custom types in the Web app `tsconfig`

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm build` *(fails: connect ENETUNREACH)*
- `pnpm lint` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb6b3c58832a99dc9712ea575590