### PR TITLE
Fix Prisma build failure

### DIFF
--- a/omnibox/package.json
+++ b/omnibox/package.json
@@ -2,7 +2,7 @@
   "name": "omnibox",
   "private": true,
   "scripts": {
-    "build": "turbo run build",
+    "build": "pnpm prisma generate && turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",


### PR DESCRIPTION
## Summary
- run `pnpm prisma generate` before building packages

## Testing
- `pnpm build` *(fails: Command "prisma" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f3ef5f18832ab90b1c2c6fb32b0e