### PR TITLE
Ensure Prisma client generation during build

### DIFF
--- a/omnibox/apps/web/package.json
+++ b/omnibox/apps/web/package.json
@@ -5,10 +5,11 @@
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",
-    "build": "next build",
+    "build": "prisma generate --schema ../../prisma/schema.prisma && next build",
     "start": "next start",
     "lint": "next lint --max-warnings 0",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "postinstall": "prisma generate --schema ../../prisma/schema.prisma"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- regenerate Prisma client before Next.js build on Vercel
- run Prisma client generation in `postinstall`

## Testing
- `pnpm install`
- `pnpm run -r --filter web build`

------
https://chatgpt.com/codex/tasks/task_e_686b906241f8832a94e130a060cc749d