### PR TITLE
Update login flow and admin pages

### DIFF
--- a/omnibox/apps/web/app/admin/layout.tsx
+++ b/omnibox/apps/web/app/admin/layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import Link from "next/link";
 import { serverSession } from "@/lib/auth";
 import { redirect } from "next/navigation";
+import { LogoutButton } from "@/components";
 
 export default async function AdminLayout({
   children,
@@ -14,8 +15,8 @@ export default async function AdminLayout({
 
   return (
     <div className="flex min-h-screen">
-      <aside className="w-48 border-r p-4 space-y-2">
-        <nav className="flex flex-col gap-2">
+      <aside className="w-48 border-r p-4 flex flex-col">
+        <nav className="flex flex-col gap-2 flex-1">
           <Link
             href="/admin/dashboard"
             className="w-full rounded px-2 py-1 text-left hover:bg-gray-100"
@@ -47,6 +48,7 @@ export default async function AdminLayout({
             Features
           </Link>
         </nav>
+        <LogoutButton />
       </aside>
       <main className="flex-1 p-4 overflow-y-auto">{children}</main>
     </div>

--- a/omnibox/apps/web/app/admin/logs/page.tsx
+++ b/omnibox/apps/web/app/admin/logs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import useSWR from "swr";
-import { Spinner, Button } from "@/components/ui";
+import { Spinner } from "@/components/ui";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -24,23 +24,41 @@ export default function LogsPage() {
       />
       {!data && <Spinner />}
       {data && (
-        <ul className="space-y-2">
-          {data.logs.map((l: any) => (
-            <li key={l.id} className="border rounded p-2 flex justify-between">
-              <span>
-                {l.timestamp} – {l.message}
-              </span>
-              <label className="inline-flex items-center gap-1">
-                <input
-                  type="checkbox"
-                  checked={l.resolved}
-                  onChange={() => resolve(l.id)}
-                />
-                Resolved
-              </label>
-            </li>
-          ))}
-        </ul>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left">
+                <th className="p-2">Timestamp</th>
+                <th className="p-2">Tenant</th>
+                <th className="p-2">Level</th>
+                <th className="p-2">Message</th>
+                <th className="p-2">Resolved</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.logs.map((l: any) => (
+                <tr key={l.id} className="border-t">
+                  <td className="p-2 whitespace-nowrap">
+                    {new Date(l.timestamp).toLocaleString()}
+                  </td>
+                  <td className="p-2">{l.tenant}</td>
+                  <td className="p-2">{l.level}</td>
+                  <td className="p-2">{l.message}</td>
+                  <td className="p-2">
+                    <label className="inline-flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={l.resolved}
+                        onChange={() => resolve(l.id)}
+                      />
+                      <span className="sr-only">Resolved</span>
+                    </label>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/omnibox/apps/web/app/admin/tenants/[id]/impersonate/page.tsx
+++ b/omnibox/apps/web/app/admin/tenants/[id]/impersonate/page.tsx
@@ -1,0 +1,8 @@
+export default function ImpersonatePage({ params }: { params: { id: string } }) {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Impersonate Tenant</h1>
+      <p>You are now impersonating tenant {params.id}.</p>
+    </div>
+  );
+}

--- a/omnibox/apps/web/app/admin/tenants/[id]/plan/page.tsx
+++ b/omnibox/apps/web/app/admin/tenants/[id]/plan/page.tsx
@@ -1,0 +1,15 @@
+import prisma from "@/lib/prisma";
+
+export default async function TenantPlanPage({ params }: { params: { id: string } }) {
+  const tenant = await prisma.user.findUnique({
+    where: { id: params.id },
+    select: { name: true, email: true },
+  });
+  if (!tenant) return <p>Tenant not found.</p>;
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Change Plan</h1>
+      <p>Manage subscription for {tenant.name ?? tenant.email}.</p>
+    </div>
+  );
+}

--- a/omnibox/apps/web/app/admin/tenants/page.tsx
+++ b/omnibox/apps/web/app/admin/tenants/page.tsx
@@ -36,10 +36,16 @@ export default async function TenantsPage() {
               <td className="p-2">N/A</td>
               <td className="p-2">N/A</td>
               <td className="p-2 text-right space-x-2">
-                <Link href="#" className="underline text-blue-600">
+                <Link
+                  href={`/admin/tenants/${u.id}/impersonate`}
+                  className="underline text-blue-600"
+                >
                   Impersonate
                 </Link>
-                <Link href="#" className="underline text-blue-600">
+                <Link
+                  href={`/admin/tenants/${u.id}/plan`}
+                  className="underline text-blue-600"
+                >
                   Change Plan
                 </Link>
                 <Link href="#" className="underline text-red-600">

--- a/omnibox/apps/web/app/api/admin/logs/route.ts
+++ b/omnibox/apps/web/app/api/admin/logs/route.ts
@@ -10,7 +10,12 @@ export async function GET(req: NextRequest) {
 
   const url = new URL(req.url);
   const q = url.searchParams.get("q")?.toLowerCase() ?? "";
-  const logs = LOGS.filter((l) => l.message.toLowerCase().includes(q));
+  const logs = LOGS.filter(
+    (l) =>
+      l.message.toLowerCase().includes(q) ||
+      l.tenant.toLowerCase().includes(q) ||
+      l.level.toLowerCase().includes(q)
+  );
   return NextResponse.json({ logs });
 }
 
@@ -23,6 +28,8 @@ export async function POST(req: NextRequest) {
   LOGS.unshift({
     id: Math.random().toString(36).slice(2),
     timestamp: new Date().toISOString(),
+    tenant: body.tenant || "unknown",
+    level: body.level || "info",
     message: body.message,
     resolved: false,
   });

--- a/omnibox/apps/web/app/dashboard/layout.tsx
+++ b/omnibox/apps/web/app/dashboard/layout.tsx
@@ -40,11 +40,13 @@ function NavLink({
   );
 }
 
+import { LogoutButton } from "@/components";
+
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex min-h-screen">
-      <aside className="w-48 sm:w-60 border-r p-4 space-y-2">
-        <nav className="flex flex-col gap-2">
+      <aside className="w-48 sm:w-60 border-r p-4 flex flex-col">
+        <nav className="flex flex-col gap-2 flex-1">
           <NavLink href="/dashboard" icon={LayoutDashboard}>Dashboard</NavLink>
           <NavLink href="/dashboard/inbox" icon={Inbox}>Inbox</NavLink>
           <NavLink href="/dashboard/deals" icon={Handshake}>Deals</NavLink>
@@ -57,6 +59,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
           <NavLink href="/dashboard/segments" icon={PieChart}>Segments</NavLink>
           <NavLink href="/dashboard/settings" icon={Settings}>Settings</NavLink>
         </nav>
+        <LogoutButton />
       </aside>
       <main className="flex-1 p-4 overflow-y-auto">{children}</main>
     </div>

--- a/omnibox/apps/web/app/page.tsx
+++ b/omnibox/apps/web/app/page.tsx
@@ -1,96 +1,16 @@
-import Image, { type ImageProps } from "next/image";
-import { Button } from "@repo/ui/button";
+import { serverSession } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import SignInPage from "./signin/page";
 
-// ThemeImage component for light/dark logos
-type Props = Omit<ImageProps, "src"> & {
-  srcLight: string;
-  srcDark: string;
-};
-const ThemeImage = (props: Props) => {
-  const { srcLight, srcDark, ...rest } = props;
-  return (
-    <>
-      <Image {...rest} src={srcLight} className="imgLight" />
-      <Image {...rest} src={srcDark} className="imgDark" />
-      <p className="text-red-500">Tailwind test – should appear red</p>
-
-    </>
-  );
-};
-
-export default function Home() {
-  return (
-    <div className="grid min-h-screen grid-rows-[20px_1fr_20px] items-center justify-items-center gap-16 p-8 md:p-20">
-      <main className="row-start-2 flex flex-col items-center gap-8 md:items-start">
-        {/* Logo with dark mode inversion */}
-        <ThemeImage
-          className="dark:invert"
-          srcLight="turborepo-dark.svg"
-          srcDark="turborepo-light.svg"
-          alt="Turborepo logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside space-y-2 text-sm leading-6 md:text-left text-center font-mono">
-          <li>
-            Get started by editing{" "}
-            <code className="rounded bg-gray-100 px-1 py-0.5 font-semibold dark:bg-gray-800">
-              apps/web/app/page.tsx
-            </code>
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
-
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <a
-            className="inline-flex items-center gap-2 rounded-full bg-gray-900 px-5 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-700 dark:bg-white dark:text-black dark:hover:bg-gray-300"
-            href="https://vercel.com/new/clone?demo-description=Learn+to+implement+a+monorepo+with+a+two+Next.js+sites+that+has+installed+three+local+packages.&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4K8ZISWAzJ8X1504ca0zmC%2F0b21a1c6246add355e55816278ef54bc%2FBasic.png&demo-title=Monorepo+with+Turborepo&demo-url=https%3A%2F%2Fexamples-basic-web.vercel.sh%2F&from=templates&project-name=Monorepo+with+Turborepo&repository-name=monorepo-turborepo&repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fturborepo%2Ftree%2Fmain%2Fexamples%2Fbasic&root-directory=apps%2Fdocs&skippable-integrations=1&teamSlug=vercel&utm_source=create-turbo"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy to Vercel
-          </a>
-          <a
-            href="https://turborepo.com/docs?utm_source"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center rounded-full border border-gray-300 px-5 py-3 text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
-          >
-            Read our docs
-          </a>
-        </div>
-        <Button
-          appName="web"
-          className="inline-flex items-center justify-center rounded-full border border-gray-300 px-5 py-3 text-sm font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
-        >
-          Open alert
-        </Button>
-      </main>
-      <footer className="row-start-3 flex flex-wrap items-center justify-center gap-6">
-        <a
-          href="https://vercel.com/templates?search=turborepo&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2 text-xs text-gray-500 hover:underline"
-        >
-          <Image
-            className="dark:invert"
-            src="/vercel.svg"
-            alt="Vercel logomark"
-            width={16}
-            height={16}
-          />
-          View Turborepo Templates
-        </a>
-      </footer>
-    </div>
-  );
+export default async function HomePage() {
+  const session = await serverSession();
+  if (session) {
+    const email = session.user?.email ?? "";
+    if (email === process.env.ADMIN_EMAIL) {
+      redirect("/admin/dashboard");
+    } else {
+      redirect("/dashboard");
+    }
+  }
+  return <SignInPage />;
 }

--- a/omnibox/apps/web/components/index.ts
+++ b/omnibox/apps/web/components/index.ts
@@ -2,3 +2,4 @@ export * from './ui';
 export * from './tag-manager';
 export * from './tags-context';
 export * from './toaster';
+export { default as LogoutButton } from './logout-button';

--- a/omnibox/apps/web/components/logout-button.tsx
+++ b/omnibox/apps/web/components/logout-button.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { signOut } from 'next-auth/react';
+
+export default function LogoutButton() {
+  return (
+    <button
+      onClick={() => signOut()}
+      className="w-full rounded px-2 py-1 text-left hover:bg-gray-100"
+    >
+      Log out
+    </button>
+  );
+}

--- a/omnibox/apps/web/lib/admin-data.ts
+++ b/omnibox/apps/web/lib/admin-data.ts
@@ -5,9 +5,13 @@ export const FLAGS: { id: string; name: string; enabled: boolean }[] = [
 
 export const TEMPLATES: { id: string; text: string }[] = [];
 
-export const LOGS: {
+export type LogEntry = {
   id: string;
   timestamp: string;
+  tenant: string;
+  level: string;
   message: string;
   resolved: boolean;
-}[] = [];
+};
+
+export const LOGS: LogEntry[] = [];


### PR DESCRIPTION
## Summary
- redirect root page to login or dashboard based on session
- add a logout button component and export it
- show logout button in user and admin sidebars
- link tenant actions to dedicated pages
- create placeholder pages for impersonation and plan changes
- improve admin logs API and list page

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm check-types` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686bb76f12b8832aa368d540e1009d55