### PR TITLE
Add admin packages

### DIFF
--- a/omnibox/apps/web/app/admin/packages/page.tsx
+++ b/omnibox/apps/web/app/admin/packages/page.tsx
@@ -1,8 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { Button, Input } from "@/components/ui";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
 export default function PackagesPage() {
+  const { data, mutate } = useSWR("/api/admin/packages", fetcher);
+  const [editing, setEditing] = useState<Record<string, any>>({});
+
+  if (!data) return null;
+
+  const pkgs = data.packages as any[];
+
+  function handleChange(id: string, field: string, value: string) {
+    setEditing((e) => ({ ...e, [id]: { ...e[id], [field]: value } }));
+  }
+
+  async function save(pkg: any) {
+    await fetch("/api/admin/packages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...pkg, ...editing[pkg.id] }),
+    });
+    setEditing((e) => ({ ...e, [pkg.id]: undefined }));
+    mutate();
+  }
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-4">
       <h1 className="text-lg font-semibold">Packages</h1>
-      <p className="text-sm text-gray-500">Manage subscription packages here.</p>
+      <p className="text-sm text-gray-500">
+        Manage subscription packages here.
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Name</th>
+              <th className="p-2">Contacts</th>
+              <th className="p-2">Deals</th>
+              <th className="p-2">Messages</th>
+              <th className="p-2">Invoices</th>
+              <th className="p-2">Revenue</th>
+              <th className="p-2">Segments</th>
+              <th className="p-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {pkgs.map((p) => {
+              const edit = editing[p.id] || {};
+              return (
+                <tr key={p.id} className="border-t">
+                  <td className="p-2">
+                    <Input
+                      value={edit.name ?? p.name}
+                      onChange={(e) =>
+                        handleChange(p.id, "name", e.target.value)
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="number"
+                      value={edit.contactsLimit ?? p.contactsLimit}
+                      onChange={(e) =>
+                        handleChange(p.id, "contactsLimit", e.target.value)
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="number"
+                      value={edit.dealsLimit ?? p.dealsLimit}
+                      onChange={(e) =>
+                        handleChange(p.id, "dealsLimit", e.target.value)
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="number"
+                      value={edit.messagingLimit ?? p.messagingLimit}
+                      onChange={(e) =>
+                        handleChange(p.id, "messagingLimit", e.target.value)
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="number"
+                      value={edit.invoicingLimit ?? p.invoicingLimit}
+                      onChange={(e) =>
+                        handleChange(p.id, "invoicingLimit", e.target.value)
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="number"
+                      value={
+                        edit.revenueReportingLimit ?? p.revenueReportingLimit
+                      }
+                      onChange={(e) =>
+                        handleChange(
+                          p.id,
+                          "revenueReportingLimit",
+                          e.target.value,
+                        )
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="number"
+                      value={edit.segmentingLimit ?? p.segmentingLimit}
+                      onChange={(e) =>
+                        handleChange(p.id, "segmentingLimit", e.target.value)
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Button onClick={() => save(p)}>Save</Button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/omnibox/apps/web/app/api/admin/packages/route.ts
+++ b/omnibox/apps/web/app/api/admin/packages/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { serverSession } from "@/lib/auth";
+import { PACKAGES, Package } from "@/lib/admin-data";
+
+export async function GET() {
+  const session = await serverSession();
+  if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  return NextResponse.json({ packages: PACKAGES });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await serverSession();
+  if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const body = (await req.json()) as Package;
+  const idx = PACKAGES.findIndex((p) => p.id === body.id);
+  if (idx === -1) {
+    PACKAGES.push(body);
+  } else {
+    PACKAGES[idx] = body;
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/lib/admin-data.ts
+++ b/omnibox/apps/web/lib/admin-data.ts
@@ -15,3 +15,47 @@ export type LogEntry = {
 };
 
 export const LOGS: LogEntry[] = [];
+
+export type Package = {
+  id: string;
+  name: string;
+  contactsLimit: number;
+  dealsLimit: number;
+  messagingLimit: number;
+  invoicingLimit: number;
+  revenueReportingLimit: number;
+  segmentingLimit: number;
+};
+
+export const PACKAGES: Package[] = [
+  {
+    id: "starter",
+    name: "Starter",
+    contactsLimit: 100,
+    dealsLimit: 5,
+    messagingLimit: 100,
+    invoicingLimit: 10,
+    revenueReportingLimit: 0,
+    segmentingLimit: 0,
+  },
+  {
+    id: "pro",
+    name: "Pro",
+    contactsLimit: 1000,
+    dealsLimit: 20,
+    messagingLimit: 1000,
+    invoicingLimit: 50,
+    revenueReportingLimit: 50,
+    segmentingLimit: 10,
+  },
+  {
+    id: "enterprise",
+    name: "Enterprise",
+    contactsLimit: 10000,
+    dealsLimit: 200,
+    messagingLimit: 10000,
+    invoicingLimit: 500,
+    revenueReportingLimit: 100,
+    segmentingLimit: 50,
+  },
+];


### PR DESCRIPTION
## Summary
- implement API and page for managing subscription packages in the admin panel
- add sample packages with limits

## Testing
- `pnpm lint` *(fails: ENETUNREACH while running turbo tasks)*
- `pnpm build` *(fails: ENETUNREACH while running turbo tasks)*

------
https://chatgpt.com/codex/tasks/task_e_686bc87092ec832ab95789a72614e265