### PR TITLE
Update register, packages, and protect dashboard

### DIFF
--- a/omnibox/apps/web/app/admin/packages/page.tsx
+++ b/omnibox/apps/web/app/admin/packages/page.tsx
@@ -1,31 +1,49 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import useSWR from "swr";
+import { v4 as uuidv4 } from "uuid";
 import { Button, Input } from "@/components/ui";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export default function PackagesPage() {
   const { data, mutate } = useSWR("/api/admin/packages", fetcher);
-  const [editing, setEditing] = useState<Record<string, any>>({});
+  const [pkgs, setPkgs] = useState<any[]>([]);
 
-  if (!data) return null;
-
-  const pkgs = data.packages as any[];
+  useEffect(() => {
+    if (data) setPkgs(data.packages);
+  }, [data]);
 
   function handleChange(id: string, field: string, value: string) {
-    setEditing((e) => ({ ...e, [id]: { ...e[id], [field]: value } }));
+    setPkgs((p) => p.map((pkg) => (pkg.id === id ? { ...pkg, [field]: value } : pkg)));
   }
 
   async function save(pkg: any) {
     await fetch("/api/admin/packages", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...pkg, ...editing[pkg.id] }),
+      body: JSON.stringify(pkg),
     });
-    setEditing((e) => ({ ...e, [pkg.id]: undefined }));
     mutate();
+  }
+
+  function addPackage() {
+    setPkgs((p) => [
+      ...p,
+      {
+        id: uuidv4(),
+        name: "",
+        contactsLimit: 0,
+        dealsLimit: 0,
+        messagingLimit: 0,
+        invoicingLimit: 0,
+        revenueReportingLimit: 0,
+        segmentingLimit: 0,
+        monthlyPrice: 0,
+        yearlyPrice: 0,
+      },
+    ]);
   }
 
   return (
@@ -34,6 +52,7 @@ export default function PackagesPage() {
       <p className="text-sm text-gray-500">
         Manage subscription packages here.
       </p>
+      <Button onClick={addPackage}>Add Package</Button>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
@@ -45,26 +64,25 @@ export default function PackagesPage() {
               <th className="p-2">Invoices</th>
               <th className="p-2">Revenue</th>
               <th className="p-2">Segments</th>
+              <th className="p-2">Monthly</th>
+              <th className="p-2">Yearly</th>
               <th className="p-2" />
             </tr>
           </thead>
           <tbody>
             {pkgs.map((p) => {
-              const edit = editing[p.id] || {};
               return (
                 <tr key={p.id} className="border-t">
                   <td className="p-2">
                     <Input
-                      value={edit.name ?? p.name}
-                      onChange={(e) =>
-                        handleChange(p.id, "name", e.target.value)
-                      }
+                      value={p.name}
+                      onChange={(e) => handleChange(p.id, "name", e.target.value)}
                     />
                   </td>
                   <td className="p-2">
                     <Input
                       type="number"
-                      value={edit.contactsLimit ?? p.contactsLimit}
+                      value={p.contactsLimit}
                       onChange={(e) =>
                         handleChange(p.id, "contactsLimit", e.target.value)
                       }
@@ -73,7 +91,7 @@ export default function PackagesPage() {
                   <td className="p-2">
                     <Input
                       type="number"
-                      value={edit.dealsLimit ?? p.dealsLimit}
+                      value={p.dealsLimit}
                       onChange={(e) =>
                         handleChange(p.id, "dealsLimit", e.target.value)
                       }
@@ -82,7 +100,7 @@ export default function PackagesPage() {
                   <td className="p-2">
                     <Input
                       type="number"
-                      value={edit.messagingLimit ?? p.messagingLimit}
+                      value={p.messagingLimit}
                       onChange={(e) =>
                         handleChange(p.id, "messagingLimit", e.target.value)
                       }
@@ -91,7 +109,7 @@ export default function PackagesPage() {
                   <td className="p-2">
                     <Input
                       type="number"
-                      value={edit.invoicingLimit ?? p.invoicingLimit}
+                      value={p.invoicingLimit}
                       onChange={(e) =>
                         handleChange(p.id, "invoicingLimit", e.target.value)
                       }
@@ -100,24 +118,36 @@ export default function PackagesPage() {
                   <td className="p-2">
                     <Input
                       type="number"
-                      value={
-                        edit.revenueReportingLimit ?? p.revenueReportingLimit
-                      }
+                      value={p.revenueReportingLimit}
                       onChange={(e) =>
-                        handleChange(
-                          p.id,
-                          "revenueReportingLimit",
-                          e.target.value,
-                        )
+                        handleChange(p.id, "revenueReportingLimit", e.target.value)
                       }
                     />
                   </td>
                   <td className="p-2">
                     <Input
                       type="number"
-                      value={edit.segmentingLimit ?? p.segmentingLimit}
+                      value={p.segmentingLimit}
                       onChange={(e) =>
                         handleChange(p.id, "segmentingLimit", e.target.value)
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="number"
+                      value={p.monthlyPrice}
+                      onChange={(e) =>
+                        handleChange(p.id, "monthlyPrice", e.target.value)
+                      }
+                    />
+                  </td>
+                  <td className="p-2">
+                    <Input
+                      type="number"
+                      value={p.yearlyPrice}
+                      onChange={(e) =>
+                        handleChange(p.id, "yearlyPrice", e.target.value)
                       }
                     />
                   </td>

--- a/omnibox/apps/web/app/dashboard/layout.tsx
+++ b/omnibox/apps/web/app/dashboard/layout.tsx
@@ -1,66 +1,14 @@
-"use client";
-
 import { ReactNode } from "react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import type { LucideIcon } from "lucide-react";
-import {
-  LayoutDashboard,
-  Inbox,
-  Handshake,
-  Calendar,
-  Users,
-  FileText,
-  MessageCircle,
-  PieChart,
-  Settings,
-} from "lucide-react";
+import { redirect } from "next/navigation";
+import { serverSession } from "@/lib/auth";
+import Sidebar from "./sidebar";
 
-function NavLink({
-  href,
-  children,
-  icon: Icon,
-}: {
-  href: string;
-  children: React.ReactNode;
-  icon: LucideIcon;
-}) {
-  const pathname = usePathname();
-  const isActive =
-    href === "/dashboard" ? pathname === href : pathname === href || pathname.startsWith(href + "/");
-  const base =
-    "flex items-center gap-2 w-full rounded px-2 py-1 text-left hover:bg-gray-100";
-  const classes =
-    base + (isActive ? " bg-gray-200 border-l-4 border-blue-600 font-medium" : "");
-  return (
-    <Link href={href} className={classes} aria-current={isActive ? "page" : undefined}>
-      <Icon className="h-4 w-4" aria-hidden="true" />
-      <span className="truncate">{children}</span>
-    </Link>
-  );
-}
-
-import { LogoutButton } from "@/components";
-
-export default function DashboardLayout({ children }: { children: ReactNode }) {
+export default async function DashboardLayout({ children }: { children: ReactNode }) {
+  const session = await serverSession();
+  if (!session) redirect("/login");
   return (
     <div className="flex min-h-screen">
-      <aside className="w-48 sm:w-60 border-r p-4 flex flex-col">
-        <nav className="flex flex-col gap-2 flex-1">
-          <NavLink href="/dashboard" icon={LayoutDashboard}>Dashboard</NavLink>
-          <NavLink href="/dashboard/inbox" icon={Inbox}>Inbox</NavLink>
-          <NavLink href="/dashboard/deals" icon={Handshake}>Deals</NavLink>
-          <NavLink href="/dashboard/calendar" icon={Calendar}>Calendar</NavLink>
-          <NavLink href="/dashboard/clients" icon={Users}>Clients</NavLink>
-          <NavLink href="/dashboard/invoices" icon={FileText}>Invoicing</NavLink>
-          <NavLink href="/dashboard/message-center" icon={MessageCircle}>
-            Message Center
-          </NavLink>
-          <NavLink href="/dashboard/segments" icon={PieChart}>Segments</NavLink>
-          <NavLink href="/dashboard/settings" icon={Settings}>Settings</NavLink>
-        </nav>
-        <LogoutButton />
-      </aside>
+      <Sidebar />
       <main className="flex-1 p-4 overflow-y-auto">{children}</main>
     </div>
   );

--- a/omnibox/apps/web/app/dashboard/sidebar.tsx
+++ b/omnibox/apps/web/app/dashboard/sidebar.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { ReactNode } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { LucideIcon } from "lucide-react";
+import {
+  LayoutDashboard,
+  Inbox,
+  Handshake,
+  Calendar,
+  Users,
+  FileText,
+  MessageCircle,
+  PieChart,
+  Settings,
+} from "lucide-react";
+import { LogoutButton } from "@/components";
+
+function NavLink({ href, children, icon: Icon }: { href: string; children: ReactNode; icon: LucideIcon }) {
+  const pathname = usePathname();
+  const isActive = href === "/dashboard" ? pathname === href : pathname === href || pathname.startsWith(href + "/");
+  const base = "flex items-center gap-2 w-full rounded px-2 py-1 text-left hover:bg-gray-100";
+  const classes = base + (isActive ? " bg-gray-200 border-l-4 border-blue-600 font-medium" : "");
+  return (
+    <Link href={href} className={classes} aria-current={isActive ? "page" : undefined}>
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      <span className="truncate">{children}</span>
+    </Link>
+  );
+}
+
+export default function Sidebar() {
+  return (
+    <aside className="w-48 sm:w-60 border-r p-4 flex flex-col">
+      <nav className="flex flex-col gap-2 flex-1">
+        <NavLink href="/dashboard" icon={LayoutDashboard}>Dashboard</NavLink>
+        <NavLink href="/dashboard/inbox" icon={Inbox}>Inbox</NavLink>
+        <NavLink href="/dashboard/deals" icon={Handshake}>Deals</NavLink>
+        <NavLink href="/dashboard/calendar" icon={Calendar}>Calendar</NavLink>
+        <NavLink href="/dashboard/clients" icon={Users}>Clients</NavLink>
+        <NavLink href="/dashboard/invoices" icon={FileText}>Invoicing</NavLink>
+        <NavLink href="/dashboard/message-center" icon={MessageCircle}>Message Center</NavLink>
+        <NavLink href="/dashboard/segments" icon={PieChart}>Segments</NavLink>
+        <NavLink href="/dashboard/settings" icon={Settings}>Settings</NavLink>
+      </nav>
+      <LogoutButton />
+    </aside>
+  );
+}

--- a/omnibox/apps/web/app/register/page.tsx
+++ b/omnibox/apps/web/app/register/page.tsx
@@ -30,7 +30,7 @@ export default async function RegisterPage() {
             <h2 className="text-lg font-semibold">General Infomation</h2>
             <input
               type="text"
-              placeholder="Company"
+              placeholder="Company Name"
               className="w-full bg-transparent border-b border-gray-300 p-3 placeholder-gray-400 text-sm focus:outline-none"
             />
             <input
@@ -63,13 +63,16 @@ export default async function RegisterPage() {
               />
             </div>
             <div className="flex gap-4">
-              <select
-                className="w-full bg-transparent border-b border-gray-300 p-3 text-sm text-gray-500 focus:outline-none"
-              >
-                {EMPLOYEES.map((e) => (
-                  <option key={e}>{e}</option>
-                ))}
-              </select>
+              <label className="w-full text-sm text-gray-600">
+                <span className="mb-1 block">Company Size</span>
+                <select
+                  className="w-full bg-transparent border-b border-gray-300 p-3 text-sm text-gray-500 focus:outline-none"
+                >
+                  {EMPLOYEES.map((e) => (
+                    <option key={e}>{e}</option>
+                  ))}
+                </select>
+              </label>
             </div>
           </form>
           <form className="bg-[#4e5cf8] text-white p-8 space-y-6">

--- a/omnibox/apps/web/components/logout-button.tsx
+++ b/omnibox/apps/web/components/logout-button.tsx
@@ -5,7 +5,7 @@ import { signOut } from 'next-auth/react';
 export default function LogoutButton() {
   return (
     <button
-      onClick={() => signOut()}
+      onClick={() => signOut({ callbackUrl: "/login" })}
       className="w-full rounded px-2 py-1 text-left hover:bg-gray-100"
     >
       Log out

--- a/omnibox/apps/web/lib/admin-data.ts
+++ b/omnibox/apps/web/lib/admin-data.ts
@@ -25,6 +25,8 @@ export type Package = {
   invoicingLimit: number;
   revenueReportingLimit: number;
   segmentingLimit: number;
+  monthlyPrice: number;
+  yearlyPrice: number;
 };
 
 export const PACKAGES: Package[] = [
@@ -37,6 +39,8 @@ export const PACKAGES: Package[] = [
     invoicingLimit: 10,
     revenueReportingLimit: 0,
     segmentingLimit: 0,
+    monthlyPrice: 10,
+    yearlyPrice: 100,
   },
   {
     id: "pro",
@@ -47,6 +51,8 @@ export const PACKAGES: Package[] = [
     invoicingLimit: 50,
     revenueReportingLimit: 50,
     segmentingLimit: 10,
+    monthlyPrice: 20,
+    yearlyPrice: 200,
   },
   {
     id: "enterprise",
@@ -57,5 +63,7 @@ export const PACKAGES: Package[] = [
     invoicingLimit: 500,
     revenueReportingLimit: 100,
     segmentingLimit: 50,
+    monthlyPrice: 50,
+    yearlyPrice: 500,
   },
 ];


### PR DESCRIPTION
## Summary
- tweak register form placeholders and labels
- allow admin to add packages with pricing
- protect dashboard routes with server-side auth check
- redirect to login when logging out

## Testing
- `pnpm lint` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686bcf96c534832a9fffeb583f9a41ee