### PR TITLE
Enhance admin package controls

### DIFF
--- a/omnibox/apps/web/app/admin/packages/page.tsx
+++ b/omnibox/apps/web/app/admin/packages/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { v4 as uuidv4 } from "uuid";
 import { Button, Input } from "@/components/ui";
+import { ArrowUp, ArrowDown, Trash } from "lucide-react";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -28,22 +29,48 @@ export default function PackagesPage() {
     mutate();
   }
 
+  async function saveOrder(newPkgs: any[]) {
+    setPkgs(newPkgs);
+    await fetch("/api/admin/packages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ packages: newPkgs }),
+    });
+    mutate();
+  }
+
+  function move(id: string, dir: "up" | "down") {
+    const index = pkgs.findIndex((p) => p.id === id);
+    const newIndex = dir === "up" ? index - 1 : index + 1;
+    if (index === -1 || newIndex < 0 || newIndex >= pkgs.length) return;
+    const copy = [...pkgs];
+    const [removed] = copy.splice(index, 1);
+    copy.splice(newIndex, 0, removed);
+    saveOrder(copy);
+  }
+
+  async function deletePackage(id: string) {
+    if (!confirm("Delete this package?")) return;
+    await fetch(`/api/admin/packages/${id}`, { method: "DELETE" });
+    setPkgs((p) => p.filter((pkg) => pkg.id !== id));
+    mutate();
+  }
+
   function addPackage() {
-    setPkgs((p) => [
-      ...p,
-      {
-        id: uuidv4(),
-        name: "",
-        contactsLimit: 0,
-        dealsLimit: 0,
-        messagingLimit: 0,
-        invoicingLimit: 0,
-        revenueReportingLimit: 0,
-        segmentingLimit: 0,
-        monthlyPrice: 0,
-        yearlyPrice: 0,
-      },
-    ]);
+    const pkg = {
+      id: uuidv4(),
+      name: "",
+      contactsLimit: 0,
+      dealsLimit: 0,
+      messagingLimit: 0,
+      invoicingLimit: 0,
+      revenueReportingLimit: 0,
+      segmentingLimit: 0,
+      monthlyPrice: 0,
+      yearlyPrice: 0,
+    };
+    setPkgs((p) => [...p, pkg]);
+    save(pkg);
   }
 
   return (
@@ -151,8 +178,29 @@ export default function PackagesPage() {
                       }
                     />
                   </td>
-                  <td className="p-2">
+                  <td className="p-2 flex items-center gap-1">
+                    <button
+                      onClick={() => move(p.id, "up")}
+                      className="p-1 hover:text-blue-600"
+                    >
+                      <ArrowUp className="h-4 w-4" />
+                      <span className="sr-only">Move up</span>
+                    </button>
+                    <button
+                      onClick={() => move(p.id, "down")}
+                      className="p-1 hover:text-blue-600"
+                    >
+                      <ArrowDown className="h-4 w-4" />
+                      <span className="sr-only">Move down</span>
+                    </button>
                     <Button onClick={() => save(p)}>Save</Button>
+                    <button
+                      onClick={() => deletePackage(p.id)}
+                      className="p-1 text-red-600 hover:text-red-700"
+                    >
+                      <Trash className="h-4 w-4" />
+                      <span className="sr-only">Delete</span>
+                    </button>
                   </td>
                 </tr>
               );

--- a/omnibox/apps/web/app/api/admin/packages/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/packages/[id]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+import { serverSession } from "@/lib/auth";
+import { PACKAGES } from "@/lib/admin-data";
+
+export async function DELETE(_req: NextRequest, { params }: any) {
+  const { id } = params as { id: string };
+  const session = await serverSession();
+  if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const idx = PACKAGES.findIndex((p) => p.id === id);
+  if (idx !== -1) PACKAGES.splice(idx, 1);
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/app/api/admin/packages/route.ts
+++ b/omnibox/apps/web/app/api/admin/packages/route.ts
@@ -15,12 +15,21 @@ export async function POST(req: NextRequest) {
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
-  const body = (await req.json()) as Package;
-  const idx = PACKAGES.findIndex((p) => p.id === body.id);
-  if (idx === -1) {
-    PACKAGES.push(body);
-  } else {
-    PACKAGES[idx] = body;
+
+  const body = await req.json();
+
+  if (Array.isArray(body.packages)) {
+    PACKAGES.splice(0, PACKAGES.length, ...body.packages);
+    return NextResponse.json({ ok: true });
   }
+
+  const pkg = body as Package;
+  const idx = PACKAGES.findIndex((p) => p.id === pkg.id);
+  if (idx === -1) {
+    PACKAGES.push(pkg);
+  } else {
+    PACKAGES[idx] = pkg;
+  }
+
   return NextResponse.json({ ok: true });
 }

--- a/omnibox/apps/web/app/signin/page.tsx
+++ b/omnibox/apps/web/app/signin/page.tsx
@@ -1,58 +1,6 @@
-/* apps/web/app/signin/page.tsx */
-'use client';
+import { redirect } from "next/navigation";
 
-import { useState } from 'react';
-import { signIn } from 'next-auth/react';
-
-export default function SignInPage() {
-  const [email, setEmail] = useState('');
-  const [status, setStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
-
-  async function handleSend() {
-    if (!email) return;
-    setStatus('sending');
-
-    // `signIn` returns a promise; we redirect manually so `redirect: false`
-    const res = await signIn('email', {
-      email,
-      redirect: false,           // stay on this page
-      callbackUrl: '/',          // where to land after e-mail link
-    });
-
-    if (res?.ok) setStatus('sent');
-    else {
-      setStatus('idle');
-      alert('Something went wrong. Is the e-mail correct?');
-    }
-  }
-
-  return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-6">
-      <h1 className="text-2xl font-semibold">Sign in</h1>
-
-      {status === 'sent' ? (
-        <p className="text-green-600">
-          Magic link sent! Check your inbox.
-        </p>
-      ) : (
-        <>
-          <input
-            className="border rounded px-3 py-2 w-64"
-            type="email"
-            placeholder="you@example.com"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-
-          <button
-            onClick={handleSend}
-            disabled={status === 'sending'}
-            className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
-          >
-            {status === 'sending' ? 'Sending…' : 'Send magic link'}
-          </button>
-        </>
-      )}
-    </main>
-  );
+export default function Page() {
+  redirect("/login");
+  return null;
 }


### PR DESCRIPTION
## Summary
- allow moving packages with up/down buttons
- let admins delete packages
- persist packages after adding
- redirect `/signin` to `/login`

## Testing
- `pnpm lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd41c407c832a8987eb32b06113cb