### PR TITLE
Fix login loop by removing /signin

### DIFF
--- a/omnibox/apps/web/app/admin/layout.tsx
+++ b/omnibox/apps/web/app/admin/layout.tsx
@@ -10,7 +10,7 @@ export default async function AdminLayout({
   children: ReactNode;
 }) {
   const session = await serverSession();
-  if (!session) redirect("/signin");
+  if (!session) redirect("/login");
   if (session.user?.email !== process.env.ADMIN_EMAIL) redirect("/");
 
   return (

--- a/omnibox/apps/web/app/login/page.tsx
+++ b/omnibox/apps/web/app/login/page.tsx
@@ -1,6 +1,6 @@
 import { serverSession } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import SignInPage from "../signin/page";
+import { LoginForm } from "@/components";
 
 export default async function LoginPage() {
   const session = await serverSession();
@@ -12,5 +12,9 @@ export default async function LoginPage() {
       redirect("/dashboard");
     }
   }
-  return <SignInPage />;
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <LoginForm />
+    </div>
+  );
 }

--- a/omnibox/apps/web/app/signin/page.tsx
+++ b/omnibox/apps/web/app/signin/page.tsx
@@ -1,6 +1,0 @@
-import { redirect } from "next/navigation";
-
-export default function Page() {
-  redirect("/login");
-  return null;
-}

--- a/omnibox/apps/web/components/index.ts
+++ b/omnibox/apps/web/components/index.ts
@@ -3,3 +3,4 @@ export * from './tag-manager';
 export * from './tags-context';
 export * from './toaster';
 export { default as LogoutButton } from './logout-button';
+export { default as LoginForm } from './login-form';

--- a/omnibox/apps/web/components/login-form.tsx
+++ b/omnibox/apps/web/components/login-form.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { signIn } from 'next-auth/react';
+import { useSearchParams } from 'next/navigation';
+import { Input, Button } from './ui';
+
+export default function LoginForm() {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get('callbackUrl') || '/dashboard';
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      await signIn('email', { email, callbackUrl });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4 bg-white rounded shadow">
+      <Input
+        type="email"
+        placeholder="Email address"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        className="w-full"
+      />
+      <Button type="submit" disabled={loading} className="bg-blue-500 text-white w-full">
+        {loading ? 'Sending...' : 'Send magic link'}
+      </Button>
+    </form>
+  );
+}

--- a/omnibox/apps/web/lib/auth.ts
+++ b/omnibox/apps/web/lib/auth.ts
@@ -27,7 +27,7 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
-  pages: { signIn: "/signin" },
+  pages: { signIn: "/login" },
   session: { strategy: "jwt" },
 };
 


### PR DESCRIPTION
## Summary
- remove `/signin` route and create client-side `LoginForm`
- export new login component
- show `LoginForm` on `/login`
- redirect admins to `/login` when necessary
- make NextAuth use `/login` as the sign-in page

## Testing
- `pnpm install --ignore-scripts`
- `pnpm lint` *(fails: connect ENETUNREACH 104.16.1.35:443)*

------
https://chatgpt.com/codex/tasks/task_e_686bda7cc738832aaff412d03efd6a23