### PR TITLE
Persist admin packages

### DIFF
--- a/omnibox/apps/web/app/api/admin/packages/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/packages/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
-import { PACKAGES } from "@/lib/admin-data";
+import { readPackages, writePackages } from "@/lib/package-store";
 
 export async function DELETE(_req: NextRequest, { params }: any) {
   const { id } = params as { id: string };
@@ -8,7 +8,11 @@ export async function DELETE(_req: NextRequest, { params }: any) {
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
-  const idx = PACKAGES.findIndex((p) => p.id === id);
-  if (idx !== -1) PACKAGES.splice(idx, 1);
+  const packages = await readPackages();
+  const idx = packages.findIndex((p) => p.id === id);
+  if (idx !== -1) {
+    packages.splice(idx, 1);
+    await writePackages(packages);
+  }
   return NextResponse.json({ ok: true });
 }

--- a/omnibox/apps/web/app/api/admin/packages/route.ts
+++ b/omnibox/apps/web/app/api/admin/packages/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
-import { PACKAGES, Package } from "@/lib/admin-data";
+import { Package } from "@/lib/admin-data";
+import { readPackages, writePackages } from "@/lib/package-store";
 
 export async function GET() {
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
-  return NextResponse.json({ packages: PACKAGES });
+  const packages = await readPackages();
+  return NextResponse.json({ packages });
 }
 
 export async function POST(req: NextRequest) {
@@ -17,19 +19,22 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json();
+  let packages = await readPackages();
 
   if (Array.isArray(body.packages)) {
-    PACKAGES.splice(0, PACKAGES.length, ...body.packages);
+    packages = body.packages;
+    await writePackages(packages);
     return NextResponse.json({ ok: true });
   }
 
   const pkg = body as Package;
-  const idx = PACKAGES.findIndex((p) => p.id === pkg.id);
+  const idx = packages.findIndex((p) => p.id === pkg.id);
   if (idx === -1) {
-    PACKAGES.push(pkg);
+    packages.push(pkg);
   } else {
-    PACKAGES[idx] = pkg;
+    packages[idx] = pkg;
   }
 
+  await writePackages(packages);
   return NextResponse.json({ ok: true });
 }

--- a/omnibox/apps/web/data/packages.json
+++ b/omnibox/apps/web/data/packages.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "starter",
+    "name": "Starter",
+    "contactsLimit": 100,
+    "dealsLimit": 5,
+    "messagingLimit": 100,
+    "invoicingLimit": 10,
+    "revenueReportingLimit": 0,
+    "segmentingLimit": 0,
+    "monthlyPrice": 10,
+    "yearlyPrice": 100
+  },
+  {
+    "id": "pro",
+    "name": "Pro",
+    "contactsLimit": 1000,
+    "dealsLimit": 20,
+    "messagingLimit": 1000,
+    "invoicingLimit": 50,
+    "revenueReportingLimit": 50,
+    "segmentingLimit": 10,
+    "monthlyPrice": 20,
+    "yearlyPrice": 200
+  },
+  {
+    "id": "enterprise",
+    "name": "Enterprise",
+    "contactsLimit": 10000,
+    "dealsLimit": 200,
+    "messagingLimit": 10000,
+    "invoicingLimit": 500,
+    "revenueReportingLimit": 100,
+    "segmentingLimit": 50,
+    "monthlyPrice": 50,
+    "yearlyPrice": 500
+  }
+]

--- a/omnibox/apps/web/lib/package-store.ts
+++ b/omnibox/apps/web/lib/package-store.ts
@@ -1,0 +1,19 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { Package } from "./admin-data";
+
+const filePath = path.join(process.cwd(), "apps/web/data/packages.json");
+
+export async function readPackages(): Promise<Package[]> {
+  try {
+    const data = await fs.readFile(filePath, "utf-8");
+    return JSON.parse(data) as Package[];
+  } catch {
+    return [];
+  }
+}
+
+export async function writePackages(packages: Package[]): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(packages, null, 2));
+}


### PR DESCRIPTION
## Summary
- persist admin package data in a JSON file
- add helper to read and write packages
- update admin package API routes to use the JSON store

## Testing
- `pnpm lint` *(fails: command exited with code 1)*
- `pnpm check-types` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_686bde13c610832ab445f15283c58475