### PR TITLE
Fix admin packages path

### DIFF
--- a/omnibox/apps/web/lib/package-store.ts
+++ b/omnibox/apps/web/lib/package-store.ts
@@ -2,7 +2,9 @@ import { promises as fs } from "fs";
 import path from "path";
 import { Package } from "./admin-data";
 
-const filePath = path.join(process.cwd(), "apps/web/data/packages.json");
+// Resolve the packages file relative to the Next.js app root so it works
+// in development and in production.
+const filePath = path.join(process.cwd(), "data", "packages.json");
 
 export async function readPackages(): Promise<Package[]> {
   try {


### PR DESCRIPTION
## Summary
- fix path resolution in `package-store.ts` so packages persist

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm check-types` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_686cdadb3fac832aa0f121895912caf6