### PR TITLE
Add tenant plan management to admin panel

### DIFF
--- a/omnibox/apps/web/app/admin/tenants/page.tsx
+++ b/omnibox/apps/web/app/admin/tenants/page.tsx
@@ -1,61 +1,172 @@
-import prisma from "@/lib/prisma";
+"use client";
+import { useState } from "react";
+import useSWR from "swr";
 import Link from "next/link";
+import { Button, Input, Badge } from "@/components/ui";
+import { MoreVertical, User, CreditCard, Trash } from "lucide-react";
 
-export default async function TenantsPage() {
-  const users = await prisma.user.findMany({
-    select: {
-      id: true,
-      email: true,
-      name: true,
-      contacts: true,
-      stripeCustomer: true,
-    },
-  });
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+type Tenant = {
+  id: string;
+  email: string;
+  name: string | null;
+  stripeCustomer: { plan: string } | null;
+};
+
+export default function TenantsPage() {
+  const [query, setQuery] = useState("");
+  const [plan, setPlan] = useState("");
+  const [addOpen, setAddOpen] = useState(false);
+  const [planTenant, setPlanTenant] = useState<Tenant | null>(null);
+  const { data, mutate } = useSWR(`/api/admin/tenants?q=${query}&plan=${plan}`, fetcher);
+
+  async function saveTenant(form: FormData) {
+    await fetch("/api/admin/tenants", {
+      method: "POST",
+      body: JSON.stringify({
+        name: form.get("name"),
+        email: form.get("email"),
+        plan: form.get("plan"),
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+    setAddOpen(false);
+    mutate();
+  }
+
+  async function changePlan(id: string, newPlan: string) {
+    await fetch(`/api/admin/tenants/${id}/plan`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plan: newPlan }),
+    });
+    setPlanTenant(null);
+    mutate();
+  }
 
   return (
     <div className="space-y-4">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="text-left">
-            <th className="p-2">Company</th>
-            <th className="p-2">Plan</th>
-            <th className="p-2">Status</th>
-            <th className="p-2">Users</th>
-            <th className="p-2">Sign-up</th>
-            <th className="p-2">Last Login</th>
-            <th className="p-2 text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {users.map((u) => (
-            <tr key={u.id} className="border-t">
-              <td className="p-2">{u.name ?? u.email}</td>
-              <td className="p-2">{u.stripeCustomer?.plan ?? "FREE"}</td>
-              <td className="p-2">active</td>
-              <td className="p-2">1</td>
-              <td className="p-2">N/A</td>
-              <td className="p-2">N/A</td>
-              <td className="p-2 text-right space-x-2">
-                <Link
-                  href={`/admin/tenants/${u.id}/impersonate`}
-                  className="underline text-blue-600"
-                >
-                  Impersonate
-                </Link>
-                <Link
-                  href={`/admin/tenants/${u.id}/plan`}
-                  className="underline text-blue-600"
-                >
-                  Change Plan
-                </Link>
-                <Link href="#" className="underline text-red-600">
-                  Cancel
-                </Link>
-              </td>
+      <div className="flex flex-wrap items-center gap-6">
+        <Input
+          className="border-b focus:outline-none"
+          placeholder="Search tenants"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <select
+          className="border-b focus:outline-none"
+          value={plan}
+          onChange={(e) => setPlan(e.target.value)}
+        >
+          <option value="">All Plans</option>
+          <option value="FREE">FREE</option>
+          <option value="PRO">PRO</option>
+        </select>
+        <Button
+          onClick={() => setAddOpen(true)}
+          className="bg-blue-600 text-white rounded-full px-4 py-1"
+        >
+          + Add Tenant
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b">
+              <th className="p-2">Company</th>
+              <th className="p-2">Plan</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Users</th>
+              <th className="p-2 text-right">Actions</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {data?.tenants.map((u: Tenant) => (
+              <tr key={u.id} className="border-t hover:bg-gray-50">
+                <td className="p-2">{u.name ?? u.email}</td>
+                <td className="p-2">
+                  <Badge className={u.stripeCustomer?.plan === "PRO" ? "bg-green-100" : "bg-gray-100"}>
+                    {u.stripeCustomer?.plan ?? "FREE"}
+                  </Badge>
+                </td>
+                <td className="p-2">active</td>
+                <td className="p-2">1</td>
+                <td className="p-2 text-right">
+                  <details className="relative">
+                    <summary className="cursor-pointer p-1 inline-block rounded hover:bg-gray-100">
+                      <MoreVertical className="h-4 w-4" />
+                    </summary>
+                    <div className="absolute right-0 mt-1 w-40 rounded border bg-white shadow-lg z-10">
+                      <Link
+                        href={`/admin/tenants/${u.id}/impersonate`}
+                        className="flex items-center gap-2 px-2 py-1 hover:bg-gray-100"
+                      >
+                        <User className="h-4 w-4" /> Impersonate
+                      </Link>
+                      <button
+                        onClick={() => setPlanTenant(u)}
+                        className="flex w-full items-center gap-2 px-2 py-1 hover:bg-gray-100"
+                      >
+                        <CreditCard className="h-4 w-4" /> Change Plan
+                      </button>
+                      <button className="flex w-full items-center gap-2 px-2 py-1 text-red-600 hover:bg-gray-100">
+                        <Trash className="h-4 w-4" /> Cancel
+                      </button>
+                    </div>
+                  </details>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {addOpen && (
+        <dialog open className="fixed inset-0 flex items-center justify-center bg-black/50" onClick={() => setAddOpen(false)}>
+          <form
+            className="w-80 space-y-2 rounded bg-white p-4 shadow"
+            onClick={(e) => e.stopPropagation()}
+            action={async (formData) => {
+              await saveTenant(formData);
+            }}
+          >
+            <h2 className="text-lg font-semibold">Add Tenant</h2>
+            <Input name="name" placeholder="Company name" className="w-full" />
+            <Input name="email" type="email" placeholder="Admin email" className="w-full" />
+            <select name="plan" className="border-b w-full">
+              <option value="FREE">FREE</option>
+              <option value="PRO">PRO</option>
+            </select>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" onClick={() => setAddOpen(false)}>Cancel</Button>
+              <Button type="submit" className="bg-blue-600 text-white">
+                Save
+              </Button>
+            </div>
+          </form>
+        </dialog>
+      )}
+
+      {planTenant && (
+        <dialog open className="fixed inset-0 flex items-center justify-center bg-black/50" onClick={() => setPlanTenant(null)}>
+          <div className="w-60 space-y-2 rounded bg-white p-4 shadow" onClick={(e) => e.stopPropagation()}>
+            <h2 className="text-lg font-semibold">Change Plan</h2>
+            <select
+              defaultValue={planTenant.stripeCustomer?.plan ?? "FREE"}
+              className="border-b w-full"
+              onChange={(e) => changePlan(planTenant.id, e.target.value)}
+            >
+              <option value="FREE">FREE</option>
+              <option value="PRO">PRO</option>
+            </select>
+            <div className="flex justify-end">
+              <Button type="button" onClick={() => setPlanTenant(null)}>Close</Button>
+            </div>
+          </div>
+        </dialog>
+      )}
     </div>
   );
 }

--- a/omnibox/apps/web/app/api/admin/tenants/[id]/plan/route.ts
+++ b/omnibox/apps/web/app/api/admin/tenants/[id]/plan/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { serverSession } from "@/lib/auth";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await serverSession();
+  if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const body = await req.json();
+  const { plan } = body;
+  await prisma.stripeCustomer.upsert({
+    where: { userId: params.id },
+    update: { plan },
+    create: {
+      userId: params.id,
+      plan,
+      stripeId: "manual",
+      currentPeriodEnd: new Date(),
+    },
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/app/api/admin/tenants/route.ts
+++ b/omnibox/apps/web/app/api/admin/tenants/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { serverSession } from "@/lib/auth";
+
+export async function GET(req: NextRequest) {
+  const session = await serverSession();
+  if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const url = new URL(req.url);
+  const q = url.searchParams.get("q") || "";
+  const plan = url.searchParams.get("plan") || "";
+
+  const where: any = {};
+  if (q) {
+    where.OR = [
+      { email: { contains: q, mode: "insensitive" } },
+      { name: { contains: q, mode: "insensitive" } },
+    ];
+  }
+  if (plan) {
+    where.stripeCustomer = { plan };
+  }
+
+  const tenants = await prisma.user.findMany({
+    where,
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      stripeCustomer: true,
+    },
+  });
+
+  return NextResponse.json({ tenants });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await serverSession();
+  if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const body = await req.json();
+  const tenant = await prisma.user.create({
+    data: {
+      email: body.email,
+      name: body.name,
+      stripeCustomer: body.plan
+        ? {
+            create: {
+              plan: body.plan,
+              stripeId: "manual",
+              currentPeriodEnd: new Date(),
+            },
+          }
+        : undefined,
+    },
+  });
+  return NextResponse.json({ tenant });
+}


### PR DESCRIPTION
## Summary
- enable interactive admin tenant management
- add API routes for tenants and plan updates
- allow admins to add tenants and change plans from the UI

## Testing
- `pnpm install`
- `pnpm lint` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686d123d1094832aaaf63918b9dad54d