### PR TITLE
Add plan renaming and tenant admin improvements

### DIFF
--- a/omnibox/apps/web/app/admin/layout.tsx
+++ b/omnibox/apps/web/app/admin/layout.tsx
@@ -48,10 +48,10 @@ export default async function AdminLayout({
             Features
           </Link>
           <Link
-            href="/admin/packages"
+            href="/admin/plans"
             className="w-full rounded px-2 py-1 text-left hover:bg-gray-100"
           >
-            Packages
+            Plans
           </Link>
         </nav>
         <LogoutButton />

--- a/omnibox/apps/web/app/admin/plans/page.tsx
+++ b/omnibox/apps/web/app/admin/plans/page.tsx
@@ -8,7 +8,7 @@ import { ArrowUp, ArrowDown, Trash } from "lucide-react";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
-export default function PackagesPage() {
+export default function PlansPage() {
   const { data, mutate } = useSWR("/api/admin/packages", fetcher);
   const [pkgs, setPkgs] = useState<any[]>([]);
 
@@ -50,7 +50,7 @@ export default function PackagesPage() {
   }
 
   async function deletePackage(id: string) {
-    if (!confirm("Delete this package?")) return;
+    if (!confirm("Delete this plan?")) return;
     await fetch(`/api/admin/packages/${id}`, { method: "DELETE" });
     setPkgs((p) => p.filter((pkg) => pkg.id !== id));
     mutate();
@@ -75,11 +75,11 @@ export default function PackagesPage() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-lg font-semibold">Packages</h1>
+      <h1 className="text-lg font-semibold">Plans</h1>
       <p className="text-sm text-gray-500">
-        Manage subscription packages here.
+        Manage subscription plans here.
       </p>
-      <Button onClick={addPackage}>Add Package</Button>
+      <Button onClick={addPackage}>Add Plan</Button>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead>

--- a/omnibox/apps/web/app/admin/tenants/page.tsx
+++ b/omnibox/apps/web/app/admin/tenants/page.tsx
@@ -3,7 +3,15 @@ import { useState } from "react";
 import useSWR from "swr";
 import Link from "next/link";
 import { Button, Input, Badge } from "@/components/ui";
-import { MoreVertical, User, CreditCard, Trash } from "lucide-react";
+import {
+  MoreVertical,
+  User,
+  CreditCard,
+  Trash,
+  ArrowUp,
+  ArrowDown,
+  Pencil,
+} from "lucide-react";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
@@ -17,9 +25,14 @@ type Tenant = {
 export default function TenantsPage() {
   const [query, setQuery] = useState("");
   const [plan, setPlan] = useState("");
+  const [status, setStatus] = useState("");
+  const [sort, setSort] = useState<{ field: string; dir: "asc" | "desc" }>({ field: "", dir: "asc" });
+  const [selected, setSelected] = useState<string[]>([]);
   const [addOpen, setAddOpen] = useState(false);
   const [planTenant, setPlanTenant] = useState<Tenant | null>(null);
-  const { data, mutate } = useSWR(`/api/admin/tenants?q=${query}&plan=${plan}`, fetcher);
+  const [editTenant, setEditTenant] = useState<(Tenant & { status: string }) | null>(null);
+  const { data: packages } = useSWR("/api/admin/packages", fetcher);
+  const { data, mutate } = useSWR(`/api/admin/tenants?q=${query}&plan=${plan}&status=${status}`, fetcher);
 
   async function saveTenant(form: FormData) {
     await fetch("/api/admin/tenants", {
@@ -45,6 +58,39 @@ export default function TenantsPage() {
     mutate();
   }
 
+  async function changeStatus(id: string, newStatus: string) {
+    await fetch(`/api/admin/tenants/${id}/status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: newStatus }),
+    });
+    mutate();
+  }
+
+  async function saveInfo(id: string, form: FormData) {
+    await fetch(`/api/admin/tenants/${id}/info`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: form.get("name"),
+        email: form.get("email"),
+      }),
+    });
+    setEditTenant(null);
+    mutate();
+  }
+
+  const tenants = data ? [...data.tenants] : [];
+  if (sort.field) {
+    tenants.sort((a: any, b: any) => {
+      const aVal = a[sort.field] ?? "";
+      const bVal = b[sort.field] ?? "";
+      if (aVal < bVal) return sort.dir === "asc" ? -1 : 1;
+      if (aVal > bVal) return sort.dir === "asc" ? 1 : -1;
+      return 0;
+    });
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-6">
@@ -60,8 +106,20 @@ export default function TenantsPage() {
           onChange={(e) => setPlan(e.target.value)}
         >
           <option value="">All Plans</option>
-          <option value="FREE">FREE</option>
-          <option value="PRO">PRO</option>
+          {packages?.packages.map((p: any) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <select
+          className="border-b focus:outline-none"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        >
+          <option value="">All Statuses</option>
+          <option value="active">Active</option>
+          <option value="inactive">Inactive</option>
         </select>
         <Button
           onClick={() => setAddOpen(true)}
@@ -72,26 +130,68 @@ export default function TenantsPage() {
       </div>
 
       <div className="overflow-x-auto">
+        {selected.length > 0 && (
+          <div className="p-2 flex gap-4 items-center text-sm">
+            <span>{selected.length} selected</span>
+            <Button
+              onClick={() => {
+                selected.forEach((id) => changeStatus(id, "inactive"));
+                setSelected([]);
+              }}
+            >
+              Deactivate
+            </Button>
+          </div>
+        )}
         <table className="w-full text-sm">
           <thead>
             <tr className="text-left border-b">
-              <th className="p-2">Company</th>
-              <th className="p-2">Plan</th>
-              <th className="p-2">Status</th>
+              <th className="p-2">
+                <input
+                  type="checkbox"
+                  checked={data && selected.length === data.tenants.length}
+                  onChange={(e) =>
+                    setSelected(
+                      e.target.checked ? tenants.map((t: any) => t.id) : []
+                    )
+                  }
+                />
+              </th>
+              <th className="p-2 cursor-pointer" onClick={() => setSort({ field: "name", dir: sort.dir === "asc" ? "desc" : "asc" })}>
+                Company {sort.field === "name" && (sort.dir === "asc" ? <ArrowUp className="inline h-3" /> : <ArrowDown className="inline h-3" />)}
+              </th>
+              <th className="p-2 cursor-pointer" onClick={() => setSort({ field: "plan", dir: sort.dir === "asc" ? "desc" : "asc" })}>
+                Plan {sort.field === "plan" && (sort.dir === "asc" ? <ArrowUp className="inline h-3" /> : <ArrowDown className="inline h-3" />)}
+              </th>
+              <th className="p-2 cursor-pointer" onClick={() => setSort({ field: "status", dir: sort.dir === "asc" ? "desc" : "asc" })}>
+                Status {sort.field === "status" && (sort.dir === "asc" ? <ArrowUp className="inline h-3" /> : <ArrowDown className="inline h-3" />)}
+              </th>
               <th className="p-2">Users</th>
               <th className="p-2 text-right">Actions</th>
             </tr>
           </thead>
           <tbody>
-            {data?.tenants.map((u: Tenant) => (
+            {tenants.map((u: any) => (
               <tr key={u.id} className="border-t hover:bg-gray-50">
-                <td className="p-2">{u.name ?? u.email}</td>
+                <td className="p-2">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(u.id)}
+                    onChange={(e) =>
+                      setSelected((s) =>
+                        e.target.checked ? [...s, u.id] : s.filter((i) => i !== u.id)
+                      )
+                    }
+                    className="mr-2"
+                  />
+                  {u.name ?? u.email}
+                </td>
                 <td className="p-2">
                   <Badge className={u.stripeCustomer?.plan === "PRO" ? "bg-green-100" : "bg-gray-100"}>
                     {u.stripeCustomer?.plan ?? "FREE"}
                   </Badge>
                 </td>
-                <td className="p-2">active</td>
+                <td className="p-2">{u.status}</td>
                 <td className="p-2">1</td>
                 <td className="p-2 text-right">
                   <details className="relative">
@@ -110,6 +210,18 @@ export default function TenantsPage() {
                         className="flex w-full items-center gap-2 px-2 py-1 hover:bg-gray-100"
                       >
                         <CreditCard className="h-4 w-4" /> Change Plan
+                      </button>
+                      <button
+                        onClick={() => changeStatus(u.id, u.status === "active" ? "inactive" : "active")}
+                        className="flex w-full items-center gap-2 px-2 py-1 hover:bg-gray-100"
+                      >
+                        <Pencil className="h-4 w-4" /> Toggle Status
+                      </button>
+                      <button
+                        onClick={() => setEditTenant(u)}
+                        className="flex w-full items-center gap-2 px-2 py-1 hover:bg-gray-100"
+                      >
+                        <Pencil className="h-4 w-4" /> Edit Info
                       </button>
                       <button className="flex w-full items-center gap-2 px-2 py-1 text-red-600 hover:bg-gray-100">
                         <Trash className="h-4 w-4" /> Cancel
@@ -136,8 +248,11 @@ export default function TenantsPage() {
             <Input name="name" placeholder="Company name" className="w-full" />
             <Input name="email" type="email" placeholder="Admin email" className="w-full" />
             <select name="plan" className="border-b w-full">
-              <option value="FREE">FREE</option>
-              <option value="PRO">PRO</option>
+              {packages?.packages.map((p: any) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
             </select>
             <div className="flex justify-end gap-2 pt-2">
               <Button type="button" onClick={() => setAddOpen(false)}>Cancel</Button>
@@ -154,17 +269,40 @@ export default function TenantsPage() {
           <div className="w-60 space-y-2 rounded bg-white p-4 shadow" onClick={(e) => e.stopPropagation()}>
             <h2 className="text-lg font-semibold">Change Plan</h2>
             <select
-              defaultValue={planTenant.stripeCustomer?.plan ?? "FREE"}
+              defaultValue={planTenant.stripeCustomer?.plan ?? ""}
               className="border-b w-full"
               onChange={(e) => changePlan(planTenant.id, e.target.value)}
             >
-              <option value="FREE">FREE</option>
-              <option value="PRO">PRO</option>
+              {packages?.packages.map((p: any) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
             </select>
             <div className="flex justify-end">
               <Button type="button" onClick={() => setPlanTenant(null)}>Close</Button>
             </div>
           </div>
+        </dialog>
+      )}
+
+      {editTenant && (
+        <dialog open className="fixed inset-0 flex items-center justify-center bg-black/50" onClick={() => setEditTenant(null)}>
+          <form
+            className="w-80 space-y-2 rounded bg-white p-4 shadow"
+            onClick={(e) => e.stopPropagation()}
+            action={async (formData) => {
+              await saveInfo(editTenant.id, formData);
+            }}
+          >
+            <h2 className="text-lg font-semibold">Edit Tenant</h2>
+            <Input name="name" defaultValue={editTenant.name ?? ""} className="w-full" />
+            <Input name="email" type="email" defaultValue={editTenant.email} className="w-full" />
+            <div className="flex justify-end gap-2 pt-2">
+              <Button type="button" onClick={() => setEditTenant(null)}>Cancel</Button>
+              <Button type="submit" className="bg-blue-600 text-white">Save</Button>
+            </div>
+          </form>
         </dialog>
       )}
     </div>

--- a/omnibox/apps/web/app/api/admin/tenants/[id]/info/route.ts
+++ b/omnibox/apps/web/app/api/admin/tenants/[id]/info/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { serverSession } from "@/lib/auth";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await serverSession();
+  if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const { name, email } = await req.json();
+  await prisma.user.update({ where: { id: params.id }, data: { name, email } });
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/app/api/admin/tenants/[id]/status/route.ts
+++ b/omnibox/apps/web/app/api/admin/tenants/[id]/status/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { serverSession } from "@/lib/auth";
+import { TENANT_STATUS } from "@/lib/admin-data";
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await serverSession();
+  if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const { status } = await req.json();
+  TENANT_STATUS[params.id] = status === "active";
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/app/api/admin/tenants/route.ts
+++ b/omnibox/apps/web/app/api/admin/tenants/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
+import { TENANT_STATUS } from "@/lib/admin-data";
 
 export async function GET(req: NextRequest) {
   const session = await serverSession();
@@ -10,6 +11,7 @@ export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const q = url.searchParams.get("q") || "";
   const plan = url.searchParams.get("plan") || "";
+  const status = url.searchParams.get("status") || "";
 
   const where: any = {};
   if (q) {
@@ -32,7 +34,14 @@ export async function GET(req: NextRequest) {
     },
   });
 
-  return NextResponse.json({ tenants });
+  const result = tenants
+    .map((t) => ({
+      ...t,
+      status: TENANT_STATUS[t.id] === false ? "inactive" : "active",
+    }))
+    .filter((t) => !status || t.status === status);
+
+  return NextResponse.json({ tenants: result });
 }
 
 export async function POST(req: NextRequest) {

--- a/omnibox/apps/web/lib/admin-data.ts
+++ b/omnibox/apps/web/lib/admin-data.ts
@@ -16,6 +16,9 @@ export type LogEntry = {
 
 export const LOGS: LogEntry[] = [];
 
+// Tracks whether a tenant is active. True by default when missing.
+export const TENANT_STATUS: Record<string, boolean> = {};
+
 export type Package = {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary
- rename `/admin/packages` section to `/admin/plans`
- add tenant status storage and API routes
- support plan and status filters and sorting
- enable editing tenant info and toggling status
- add bulk selection and actions in tenants table

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `prisma: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d199c23fc832a8ef304f99a625757