### PR TITLE
Fix dynamic tenant routes and enum

### DIFF
--- a/omnibox/apps/web/app/admin/dashboard/page.tsx
+++ b/omnibox/apps/web/app/admin/dashboard/page.tsx
@@ -3,7 +3,7 @@ import prisma from "@/lib/prisma";
 export default async function AdminDashboard() {
   const totalCustomers = await prisma.user.count();
   const proCount = await prisma.stripeCustomer.count({
-    where: { plan: "PRO" },
+    where: { plan: "pro" },
   });
   const mrr = proCount * 10; // assume $10 per PRO subscription
   const churnRate = 0; // placeholder

--- a/omnibox/apps/web/app/admin/tenants/[id]/impersonate/page.tsx
+++ b/omnibox/apps/web/app/admin/tenants/[id]/impersonate/page.tsx
@@ -1,8 +1,9 @@
-export default function ImpersonatePage({ params }: { params: { id: string } }) {
+export default async function ImpersonatePage({ params }: any) {
+  const { id } = (await params) as { id: string };
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">Impersonate Tenant</h1>
-      <p>You are now impersonating tenant {params.id}.</p>
+      <p>You are now impersonating tenant {id}.</p>
     </div>
   );
 }

--- a/omnibox/apps/web/app/admin/tenants/[id]/plan/page.tsx
+++ b/omnibox/apps/web/app/admin/tenants/[id]/plan/page.tsx
@@ -1,8 +1,9 @@
 import prisma from "@/lib/prisma";
 
-export default async function TenantPlanPage({ params }: { params: { id: string } }) {
+export default async function TenantPlanPage({ params }: any) {
+  const { id } = (await params) as { id: string };
   const tenant = await prisma.user.findUnique({
-    where: { id: params.id },
+    where: { id },
     select: { name: true, email: true },
   });
   if (!tenant) return <p>Tenant not found.</p>;

--- a/omnibox/apps/web/app/admin/tenants/page.tsx
+++ b/omnibox/apps/web/app/admin/tenants/page.tsx
@@ -187,8 +187,8 @@ export default function TenantsPage() {
                   {u.name ?? u.email}
                 </td>
                 <td className="p-2">
-                  <Badge className={u.stripeCustomer?.plan === "PRO" ? "bg-green-100" : "bg-gray-100"}>
-                    {u.stripeCustomer?.plan ?? "FREE"}
+                  <Badge className={u.stripeCustomer?.plan === "pro" ? "bg-green-100" : "bg-gray-100"}>
+                    {u.stripeCustomer?.plan ?? "starter"}
                   </Badge>
                 </td>
                 <td className="p-2">{u.status}</td>

--- a/omnibox/apps/web/app/api/admin/tenants/[id]/info/route.ts
+++ b/omnibox/apps/web/app/api/admin/tenants/[id]/info/route.ts
@@ -2,12 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: any) {
+  const { id } = (await params) as { id: string };
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
   const { name, email } = await req.json();
-  await prisma.user.update({ where: { id: params.id }, data: { name, email } });
+  await prisma.user.update({ where: { id }, data: { name, email } });
   return NextResponse.json({ ok: true });
 }

--- a/omnibox/apps/web/app/api/admin/tenants/[id]/plan/route.ts
+++ b/omnibox/apps/web/app/api/admin/tenants/[id]/plan/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: any) {
+  const { id } = (await params) as { id: string };
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });
@@ -10,10 +11,10 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const body = await req.json();
   const { plan } = body;
   await prisma.stripeCustomer.upsert({
-    where: { userId: params.id },
+    where: { userId: id },
     update: { plan },
     create: {
-      userId: params.id,
+      userId: id,
       plan,
       stripeId: "manual",
       currentPeriodEnd: new Date(),

--- a/omnibox/apps/web/app/api/admin/tenants/[id]/status/route.ts
+++ b/omnibox/apps/web/app/api/admin/tenants/[id]/status/route.ts
@@ -2,12 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
 import { TENANT_STATUS } from "@/lib/admin-data";
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(req: NextRequest, { params }: any) {
+  const { id } = (await params) as { id: string };
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
   const { status } = await req.json();
-  TENANT_STATUS[params.id] = status === "active";
+  TENANT_STATUS[id] = status === "active";
   return NextResponse.json({ ok: true });
 }

--- a/omnibox/apps/web/app/api/billing/route.ts
+++ b/omnibox/apps/web/app/api/billing/route.ts
@@ -8,5 +8,5 @@ export async function GET() {
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
   if (!user) return NextResponse.json({ status: "unknown" });
   const customer = await prisma.stripeCustomer.findFirst({ where: { userId: user.id } });
-  return NextResponse.json({ plan: customer?.plan ?? "FREE" });
+  return NextResponse.json({ plan: customer?.plan ?? "starter" });
 }

--- a/omnibox/prisma/schema.prisma
+++ b/omnibox/prisma/schema.prisma
@@ -26,8 +26,9 @@ enum Stage {
 }
 
 enum Plan {
-  FREE
-  PRO
+  starter
+  pro
+  enterprise
 }
 
 model User {


### PR DESCRIPTION
## Summary
- support async params in admin tenant API routes and pages
- rename plan enum to match package ids
- update admin dashboard and billing defaults for new plan names

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm exec prisma generate --schema prisma/schema.prisma`
- `pnpm lint` *(fails: ENETUNREACH to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686d1c5e8828832aa8c889b025b266cb