### PR TITLE
Update segments page UI

### DIFF
--- a/omnibox/apps/web/app/dashboard/segments/components/SegmentTable.tsx
+++ b/omnibox/apps/web/app/dashboard/segments/components/SegmentTable.tsx
@@ -1,15 +1,13 @@
 "use client";
 import InlineNameEditor from "./InlineNameEditor";
-import SegmentRowMenu from "./SegmentRowMenu";
 import BulkToolbar from "./BulkToolbar";
 import { Segment } from "../types";
 import { useState } from "react";
+import { Edit2, Trash2 } from "lucide-react";
 
 interface Props {
   segments: Segment[];
   countFor: (seg: Segment) => number;
-  onRun: (seg: Segment) => void;
-  onExport: (seg: Segment) => void;
   onEdit: (seg: Segment, name: string) => void;
   onDelete: (id: string) => void;
   onBulkDelete: (ids: string[]) => void;
@@ -19,8 +17,6 @@ interface Props {
 export default function SegmentTable({
   segments,
   countFor,
-  onRun,
-  onExport,
   onEdit,
   onDelete,
   onBulkDelete,
@@ -75,12 +71,24 @@ export default function SegmentTable({
                 {new Date(s.createdAt).toLocaleDateString()}
               </td>
               <td className="p-2 text-right">
-                <SegmentRowMenu
-                  onRun={() => onRun(s)}
-                  onExport={() => onExport(s)}
-                  onEdit={() => onEdit(s, s.name)}
-                  onDelete={() => onDelete(s.id)}
-                />
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    title="Edit"
+                    aria-label="Edit"
+                    onClick={() => onEdit(s, s.name)}
+                  >
+                    <Edit2 className="h-4 w-4 text-[#888] hover:text-[#555]" />
+                  </button>
+                  <button
+                    type="button"
+                    title="Delete"
+                    aria-label="Delete"
+                    onClick={() => onDelete(s.id)}
+                  >
+                    <Trash2 className="h-4 w-4 text-[#888] hover:text-[#555]" />
+                  </button>
+                </div>
               </td>
             </tr>
           ))}

--- a/omnibox/apps/web/app/dashboard/segments/page.tsx
+++ b/omnibox/apps/web/app/dashboard/segments/page.tsx
@@ -184,42 +184,64 @@ function Segments() {
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-semibold">Segments</h1>
-      <div className="flex flex-col items-center justify-center gap-2 sm:flex-row">
-        <Input
-          placeholder="Search segments"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-60"
-        />
-        <button
-          type="button"
-          onClick={openNew}
-          className="px-3 py-1 rounded border shadow-sm whitespace-nowrap border-green-700 bg-green-600 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
-        >
-          Create segment
-        </button>
-      </div>
-      <SegmentTable
-        segments={filteredSegments}
-        countFor={(seg) => clientsForSegment(seg).length}
-        onRun={(seg) => setSelected(seg)}
-        onExport={(seg) => exportCSV(clientsForSegment(seg))}
-        onEdit={(seg, newName) => {
-          updateSegments.mutate(
-            segments.map((s) =>
-              s.id === seg.id ? { ...s, name: newName } : s,
-            ),
-          );
-        }}
-        onDelete={deleteSegment}
-        onBulkDelete={bulkDelete}
-        onBulkExport={(ids) =>
-          ids.forEach((id) => {
-            const seg = segments.find((s) => s.id === id);
-            if (seg) exportCSV(clientsForSegment(seg));
-          })
-        }
-      />
+      {segments.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-10">
+          <img
+            src="/connected-dots.svg"
+            alt=""
+            width={200}
+            height={200}
+            className="mx-auto"
+          />
+          <p className="mt-4 text-base text-[#666]">
+            You haven’t created any segments yet.
+          </p>
+          <Button
+            type="button"
+            onClick={openNew}
+            className="mt-4 bg-green-600 text-base text-white"
+          >
+            + Create Segment
+          </Button>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col items-center justify-center gap-2 sm:flex-row">
+            <Input
+              placeholder="Search segments"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-60"
+            />
+            <button
+              type="button"
+              onClick={openNew}
+              className="px-3 py-1 rounded border shadow-sm whitespace-nowrap border-green-700 bg-green-600 text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+            >
+              Create segment
+            </button>
+          </div>
+          <SegmentTable
+            segments={filteredSegments}
+            countFor={(seg) => clientsForSegment(seg).length}
+            onEdit={(seg, newName) => {
+              updateSegments.mutate(
+                segments.map((s) =>
+                  s.id === seg.id ? { ...s, name: newName } : s,
+                ),
+              );
+            }}
+            onDelete={deleteSegment}
+            onBulkDelete={bulkDelete}
+            onBulkExport={(ids) =>
+              ids.forEach((id) => {
+                const seg = segments.find((s) => s.id === id);
+                if (seg) exportCSV(clientsForSegment(seg));
+              })
+            }
+          />
+        </>
+      )}
 
       {selected && (
         <div

--- a/omnibox/apps/web/public/connected-dots.svg
+++ b/omnibox/apps/web/public/connected-dots.svg
@@ -1,0 +1,10 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="40" cy="160" r="16" fill="#E5E7EB"/>
+  <circle cx="100" cy="40" r="16" fill="#E5E7EB"/>
+  <circle cx="160" cy="80" r="16" fill="#E5E7EB"/>
+  <circle cx="140" cy="160" r="16" fill="#E5E7EB"/>
+  <line x1="40" y1="160" x2="100" y2="40" stroke="#CBD5E1" stroke-width="4"/>
+  <line x1="100" y1="40" x2="160" y2="80" stroke="#CBD5E1" stroke-width="4"/>
+  <line x1="160" y1="80" x2="140" y2="160" stroke="#CBD5E1" stroke-width="4"/>
+  <line x1="40" y1="160" x2="140" y2="160" stroke="#CBD5E1" stroke-width="4"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a connected-dots illustration for the empty state
- simplify `SegmentTable` actions to edit/delete icons
- show an empty-state panel on the Segments page when there are no segments

## Testing
- `pnpm lint` *(fails: turbo not found)*
- `pnpm build` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3af5e9f0832aa24c895c34684a23