### PR TITLE
Implement password reset feature

### DIFF
--- a/omnibox/apps/web/app/api/forgot-password/route.ts
+++ b/omnibox/apps/web/app/api/forgot-password/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { hash } from "bcryptjs";
+import sgMail from "@sendgrid/mail";
+import crypto from "node:crypto";
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY!);
+const EMAIL_FROM = process.env.EMAIL_FROM!;
+
+export async function POST(req: NextRequest) {
+  const { email } = await req.json();
+  if (!email) {
+    return NextResponse.json({ error: "Missing email" }, { status: 400 });
+  }
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    return NextResponse.json({ ok: true });
+  }
+  const newPassword = crypto.randomBytes(8).toString("hex");
+  const hashedPassword = await hash(newPassword, 10);
+  await prisma.user.update({ where: { email }, data: { hashedPassword } });
+  await sgMail.send({
+    to: email,
+    from: EMAIL_FROM,
+    subject: "Your new password",
+    text: `Your new password is: ${newPassword}`,
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/omnibox/apps/web/app/forgot-password/page.tsx
+++ b/omnibox/apps/web/app/forgot-password/page.tsx
@@ -1,0 +1,20 @@
+import { serverSession } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { ForgotPasswordForm } from "@/components";
+
+export default async function ForgotPasswordPage() {
+  const session = await serverSession();
+  if (session) {
+    const email = session.user?.email ?? "";
+    if (email === process.env.ADMIN_EMAIL) {
+      redirect("/admin/dashboard");
+    } else {
+      redirect("/dashboard");
+    }
+  }
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <ForgotPasswordForm />
+    </div>
+  );
+}

--- a/omnibox/apps/web/components/forgot-password-form.tsx
+++ b/omnibox/apps/web/components/forgot-password-form.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState, FormEvent } from 'react';
+import { Input, Button } from './ui';
+import { toast } from 'sonner';
+
+export default function ForgotPasswordForm() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch('/api/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      if (res.ok) {
+        toast.success('Check your email for a new password.');
+      } else {
+        toast.error('Failed to reset password');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4 bg-white rounded shadow">
+      <Input
+        type="email"
+        placeholder="Email address"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+        className="w-full"
+      />
+      <Button type="submit" disabled={loading} className="bg-blue-500 text-white w-full">
+        {loading ? 'Sending...' : 'Send new password'}
+      </Button>
+    </form>
+  );
+}

--- a/omnibox/apps/web/components/index.ts
+++ b/omnibox/apps/web/components/index.ts
@@ -4,3 +4,4 @@ export * from './tags-context';
 export * from './toaster';
 export { default as LogoutButton } from './logout-button';
 export { default as LoginForm } from './login-form';
+export { default as ForgotPasswordForm } from './forgot-password-form';

--- a/omnibox/apps/web/components/login-form.tsx
+++ b/omnibox/apps/web/components/login-form.tsx
@@ -4,6 +4,7 @@ import { useState, FormEvent } from 'react';
 import { signIn } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { Input, Button } from './ui';
+import Link from 'next/link';
 
 export default function LoginForm() {
   const searchParams = useSearchParams();
@@ -43,6 +44,11 @@ export default function LoginForm() {
       <Button type="submit" disabled={loading} className="bg-blue-500 text-white w-full">
         {loading ? 'Logging in...' : 'Login'}
       </Button>
+      <div className="text-center">
+        <Link href="/forgot-password" className="text-sm text-blue-600 hover:underline">
+          Forgot password?
+        </Link>
+      </div>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- add forgot password email route
- add forgot password page and form
- link to password reset from login form

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm exec tsc -p apps/web/tsconfig.json --noEmit` *(fails: ... deals page type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686e5b8441d8832ab319dd574cf3d7e5