### PR TITLE
Add back-to-login button

### DIFF
--- a/omnibox/apps/web/components/forgot-password-form.tsx
+++ b/omnibox/apps/web/components/forgot-password-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, FormEvent } from 'react';
 import { Input, Button } from './ui';
+import Link from 'next/link';
 import { toast } from 'sonner';
 
 export default function ForgotPasswordForm() {
@@ -40,6 +41,11 @@ export default function ForgotPasswordForm() {
       <Button type="submit" disabled={loading} className="bg-blue-500 text-white w-full">
         {loading ? 'Sending...' : 'Send new password'}
       </Button>
+      <Link href="/login">
+        <Button type="button" className="bg-green-500 text-white w-full">
+          Back to login
+        </Button>
+      </Link>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- add a link import to the forgot-password form
- add a green button linking back to the login page

## Testing
- `pnpm lint` *(fails: turbo not found; node modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e7b5b3a54832a80702bf25295f766