### PR TITLE
Improve admin UI

### DIFF
--- a/omnibox/apps/web/app/admin/layout.tsx
+++ b/omnibox/apps/web/app/admin/layout.tsx
@@ -15,7 +15,7 @@ export default async function AdminLayout({
 
   return (
     <div className="flex min-h-screen">
-      <aside className="w-48 border-r p-4 flex flex-col">
+      <aside className="w-48 border-r p-4 flex flex-col h-screen sticky top-0 flex-shrink-0">
         <nav className="flex flex-col gap-2 flex-1">
           <Link
             href="/admin/dashboard"


### PR DESCRIPTION
## Summary
- keep sidebar fixed so it stays visible while scrolling
- close user action dropdown on outside click
- add sort arrows to /admin/users table
- allow editing, reactivation, and plan updates for a user

## Testing
- `pnpm lint` *(fails: command not found or network issue)*
- `pnpm build` *(fails: command not found or network issue)*

------
https://chatgpt.com/codex/tasks/task_e_686f5b35224c832a920b71853166be77