### PR TITLE
Fix plan type

### DIFF
--- a/omnibox/prisma/migrations/20250801090000_change_plan_to_string/migration.sql
+++ b/omnibox/prisma/migrations/20250801090000_change_plan_to_string/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "StripeCustomer" ALTER COLUMN "plan" TYPE TEXT USING "plan"::text;
+DROP TYPE IF EXISTS "Plan";

--- a/omnibox/prisma/schema.prisma
+++ b/omnibox/prisma/schema.prisma
@@ -25,11 +25,6 @@ enum Stage {
   DONE
 }
 
-enum Plan {
-  starter
-  pro
-  enterprise
-}
 
 model User {
   id              String           @id @default(uuid())
@@ -96,7 +91,7 @@ model StripeCustomer {
   userId           String   @unique
   user             User     @relation(fields: [userId], references: [id])
   stripeId         String
-  plan             Plan
+  plan             String
   currentPeriodEnd DateTime
 }
 


### PR DESCRIPTION
## Summary
- allow string plan in StripeCustomer
- add migration to convert the enum column

## Testing
- `pnpm lint` *(fails: ENETUNREACH)*
- `pnpm build` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686f6c873ad8832abca9eb7614ea2c4e