### PR TITLE
Fix params typings in Next.js routes

### DIFF
--- a/omnibox/apps/web/app/api/admin/features/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/features/[id]/route.ts
@@ -4,9 +4,9 @@ import { FLAGS } from "@/lib/admin-data";
 
 export async function POST(
   req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });

--- a/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
+++ b/omnibox/apps/web/app/api/admin/logs/[id]/route.ts
@@ -4,9 +4,9 @@ import { LOGS } from "@/lib/admin-data";
 
 export async function POST(
   req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });

--- a/omnibox/apps/web/app/api/admin/users/[id]/info/route.ts
+++ b/omnibox/apps/web/app/api/admin/users/[id]/info/route.ts
@@ -2,8 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 
-export async function POST(req: NextRequest, { params }: any) {
-  const { id } = (await params) as { id: string };
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const { id } = params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });

--- a/omnibox/apps/web/app/api/admin/users/[id]/plan/route.ts
+++ b/omnibox/apps/web/app/api/admin/users/[id]/plan/route.ts
@@ -2,8 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { serverSession } from "@/lib/auth";
 
-export async function POST(req: NextRequest, { params }: any) {
-  const { id } = (await params) as { id: string };
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const { id } = params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });

--- a/omnibox/apps/web/app/api/admin/users/[id]/status/route.ts
+++ b/omnibox/apps/web/app/api/admin/users/[id]/status/route.ts
@@ -2,8 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { serverSession } from "@/lib/auth";
 import { TENANT_STATUS } from "@/lib/admin-data";
 
-export async function POST(req: NextRequest, { params }: any) {
-  const { id } = (await params) as { id: string };
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const { id } = params;
   const session = await serverSession();
   if (!session || session.user?.email !== process.env.ADMIN_EMAIL) {
     return new NextResponse("Unauthorized", { status: 401 });

--- a/omnibox/apps/web/app/api/client/[id]/route.ts
+++ b/omnibox/apps/web/app/api/client/[id]/route.ts
@@ -5,9 +5,9 @@ import { Prisma } from "@prisma/client";
 
 export async function PATCH(
   req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({
@@ -59,9 +59,9 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({

--- a/omnibox/apps/web/app/api/deal/[id]/route.ts
+++ b/omnibox/apps/web/app/api/deal/[id]/route.ts
@@ -4,9 +4,9 @@ import { serverSession } from "@/lib/auth";
 
 export async function PATCH(
   req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -24,9 +24,9 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? "ee.altuntas@gmail.com";
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });

--- a/omnibox/apps/web/app/api/invoice/[id]/route.ts
+++ b/omnibox/apps/web/app/api/invoice/[id]/route.ts
@@ -9,9 +9,9 @@ const EMAIL_FROM = process.env.EMAIL_FROM!;
 
 export async function GET(
   _req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -28,9 +28,9 @@ export async function GET(
 
 export async function PATCH(
   req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });
@@ -195,9 +195,9 @@ export async function PATCH(
 
 export async function DELETE(
   _req: NextRequest,
-  { params }: any,
+  { params }: { params: { id: string } },
 ) {
-  const { id } = (await params) as { id: string };
+  const { id } = params;
   const session = await serverSession();
   let email = session?.user?.email ?? 'ee.altuntas@gmail.com';
   const user = await prisma.user.findFirst({ where: { email }, select: { id: true } });


### PR DESCRIPTION
## Summary
- remove unnecessary `await params` in Next.js route handlers
- add typed `params` argument `{ params: { id: string } }`

## Testing
- `npm install` *(success)*
- `npm run lint` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686f859586e8832abf7dad7a5d3f6bd8