### PR TITLE
Fix login failure after password reset

### DIFF
--- a/omnibox/apps/web/app/api/forgot-password/route.ts
+++ b/omnibox/apps/web/app/api/forgot-password/route.ts
@@ -18,7 +18,14 @@ export async function POST(req: NextRequest) {
   }
   const newPassword = crypto.randomBytes(8).toString("hex");
   const hashedPassword = await hash(newPassword, 10);
-  await prisma.user.update({ where: { email }, data: { hashedPassword } });
+  await prisma.user.update({
+    where: { email },
+    data: {
+      hashedPassword,
+      emailVerified: new Date(),
+    },
+  });
+  await prisma.verificationToken.deleteMany({ where: { identifier: email } });
   await sgMail.send({
     to: email,
     from: EMAIL_FROM,


### PR DESCRIPTION
## Summary
- update forgot password handler to mark email as verified
- remove leftover verification tokens when resetting password

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm lint` *(fails: ADMIN_EMAIL not listed in turbo.json)*
- `pnpm build` *(fails: docs build issues)*


------
https://chatgpt.com/codex/tasks/task_e_687518529c84832ab2095feeb13ef24e